### PR TITLE
Fix unit tests

### DIFF
--- a/config/testcrds/machineset.openshift.io.crd.yaml
+++ b/config/testcrds/machineset.openshift.io.crd.yaml
@@ -1,0 +1,131 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: machinesets.machine.openshift.io
+spec:
+  group: machine.openshift.io
+  names:
+    kind: MachineSet
+    plural: machinesets
+  scope: Namespaced
+  subresources:
+    scale:
+      labelSelectorPath: .status.labelSelector
+      specReplicasPath: .spec.replicas
+      statusReplicasPath: .status.replicas
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          type: object
+          properties:
+            minReadySeconds:
+              format: int32
+              type: integer
+            replicas:
+              format: int32
+              type: integer
+            selector:
+              type: object
+            template:
+              type: object
+              properties:
+                metadata:
+                  type: object
+                spec:
+                  type: object
+                  properties:
+                    configSource:
+                      type: object
+                    metadata:
+                      type: object
+                    providerSpec:
+                      properties:
+                        value:
+                          type: object
+                        valueFrom:
+                          properties:
+                            machineClass:
+                              properties:
+                                provider:
+                                  type: string
+                              type: object
+                          type: object
+                      type: object
+                    taints:
+                      items:
+                        type: object
+                      type: array
+                    versions:
+                      properties:
+                        controlPlane:
+                          type: string
+                        kubelet:
+                          type: string
+                      required:
+                      - kubelet
+                      type: object
+                  required:
+                  - providerSpec
+          required:
+          - selector
+        status:
+          properties:
+            availableReplicas:
+              format: int32
+              type: integer
+            errorMessage:
+              type: string
+            errorReason:
+              type: string
+            fullyLabeledReplicas:
+              format: int32
+              type: integer
+            observedGeneration:
+              format: int64
+              type: integer
+            readyReplicas:
+              format: int32
+              type: integer
+            replicas:
+              format: int32
+              type: integer
+          required:
+          - replicas
+          type: object
+  version: v1beta1
+  additionalPrinterColumns:
+  - JSONPath: .spec.replicas
+    description: Desired Replicas
+    name: Desired
+    type: integer
+  - JSONPath: .status.replicas
+    description: Current Replicas
+    name: Current
+    type: integer
+  - JSONPath: .status.readyReplicas
+    description: Ready Replicas
+    name: Ready
+    type: integer
+  - JSONPath: .status.availableReplicas
+    name: Available
+    description: Observed number of available replicas
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/pkg/machineset/controller_suite_test.go
+++ b/pkg/machineset/controller_suite_test.go
@@ -37,7 +37,7 @@ func TestReconciler(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths: []string{filepath.Join("..", "..", "..", "..", "config", "testcrds")},
+		CRDDirectoryPaths: []string{filepath.Join("..", "..", "config", "testcrds")},
 	}
 	machinev1.AddToScheme(scheme.Scheme)
 


### PR DESCRIPTION
The CRD was mistakenly removed with f08e9ebf, while the path to the CRDs
wasn't updated after b9e73dd4.