### PR TITLE
Add OpenShift CAPO default tags

### DIFF
--- a/pkg/machine/actuator.go
+++ b/pkg/machine/actuator.go
@@ -31,6 +31,7 @@ import (
 
 	openstackconfigv1 "github.com/openshift/machine-api-provider-openstack/pkg/apis/openstackproviderconfig/v1alpha1"
 	"github.com/openshift/machine-api-provider-openstack/pkg/clients"
+	"github.com/openshift/machine-api-provider-openstack/pkg/utils"
 
 	machinev1 "github.com/openshift/api/machine/v1beta1"
 	configclient "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
@@ -244,7 +245,7 @@ func (oc *OpenstackClient) createInstance(ctx context.Context, machine *machinev
 	}
 
 	osCluster := getOSCluster()
-	clusterNameWithNamespace := getClusterNameWithNamespace(machine)
+	clusterNameWithNamespace := utils.GetClusterNameWithNamespace(machine)
 	instanceStatus, err := computeService.CreateInstance(&osCluster, &v1Machine, osMachine, clusterNameWithNamespace, userDataRendered)
 	if err != nil {
 		return nil, maoMachine.CreateMachine("error creating Openstack instance: %v", err)
@@ -275,7 +276,7 @@ func reconcileFloatingIP(machine *machinev1.Machine, providerSpec *openstackconf
 		return err
 	}
 	osCluster := getOSCluster()
-	fp, err := networkService.GetOrCreateFloatingIP(&osCluster, getClusterNameWithNamespace(machine), providerSpec.FloatingIP)
+	fp, err := networkService.GetOrCreateFloatingIP(&osCluster, utils.GetClusterNameWithNamespace(machine), providerSpec.FloatingIP)
 	if err != nil {
 		return fmt.Errorf("get floatingIP err: %v", err)
 	}

--- a/pkg/machine/utils.go
+++ b/pkg/machine/utils.go
@@ -17,11 +17,8 @@ limitations under the License.
 package machine
 
 import (
-	"fmt"
-
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/utils/openstack/clientconfig"
-	machinev1 "github.com/openshift/api/machine/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/cloud/services/compute"
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/cloud/services/networking"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -61,9 +58,4 @@ func (osc *openStackContext) getNetworkService() (*networking.Service, error) {
 		osc.networkService = networkService
 	}
 	return osc.networkService, nil
-}
-
-func getClusterNameWithNamespace(machine *machinev1.Machine) string {
-	clusterName := machine.Labels[machinev1.MachineClusterIDLabel]
-	return fmt.Sprintf("%s-%s", machine.Namespace, clusterName)
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,0 +1,11 @@
+package utils
+
+import (
+	"fmt"
+	machinev1 "github.com/openshift/api/machine/v1beta1"
+)
+
+func GetClusterNameWithNamespace(machine *machinev1.Machine) string {
+	clusterName := machine.Labels[machinev1.MachineClusterIDLabel]
+	return fmt.Sprintf("%s-%s", machine.Namespace, clusterName)
+}


### PR DESCRIPTION
In CAPO we were adding default tags to VMs and ports. This commit makes
sure MAPO adds them too. I don't think they're useful and the one built
from machine namespace and cluster ID is just weird, but anyway we
should attempt to maintain the API contract.