### PR TITLE
Depend on the downstream CAPO

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -114,4 +114,7 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.0 // indirect
 )
 
-replace sigs.k8s.io/cluster-api => sigs.k8s.io/cluster-api v1.0.2
+replace (
+	sigs.k8s.io/cluster-api => sigs.k8s.io/cluster-api v1.0.2
+	sigs.k8s.io/cluster-api-provider-openstack => github.com/openshift/cluster-api-provider-openstack v0.5.1-0.20220113110629-19889578bf84
+)

--- a/go.sum
+++ b/go.sum
@@ -818,6 +818,8 @@ github.com/openshift/build-machinery-go v0.0.0-20210712174854-1bb7fd1518d3/go.mo
 github.com/openshift/build-machinery-go v0.0.0-20211213093930-7e33a7eb4ce3/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20211209144617-7385dd6338e3 h1:SG1aqwleU6bGD0X4mhkTNupjVnByMYYuW4XbnCPavQU=
 github.com/openshift/client-go v0.0.0-20211209144617-7385dd6338e3/go.mod h1:cwhyki5lqBmrT0m8Im+9I7PGFaraOzcYPtEz93RcsGY=
+github.com/openshift/cluster-api-provider-openstack v0.5.1-0.20220113110629-19889578bf84 h1:lHIUlc0+eLjhEQWhnzhNQC4hdLOeIZt43J2m+wJZG/U=
+github.com/openshift/cluster-api-provider-openstack v0.5.1-0.20220113110629-19889578bf84/go.mod h1:DjUUwFBscjYRihaHOXVMtNlBBazsstagsGO72TrqUik=
 github.com/openshift/library-go v0.0.0-20211220195323-eca2c467c492 h1:oj/rSQqVWVj6YJUydZwLz2frrJreiyI4oa9g/YPgMsM=
 github.com/openshift/library-go v0.0.0-20211220195323-eca2c467c492/go.mod h1:4UQ9snU1vg53fyTpHQw3vLPiAxI8ub5xrc+y8KPQQFs=
 github.com/openshift/machine-api-operator v0.2.1-0.20211223185609-7ba373c29f8f h1:op3c+b/cPqdApZQUfueoSvBqIrqg772nXPe3pB+PFi4=
@@ -1734,8 +1736,6 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.22/go.mod h1:LEScyz
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.25/go.mod h1:Mlj9PNLmG9bZ6BHFwFKDo5afkpWyUISkb9Me0GnK66I=
 sigs.k8s.io/cluster-api v1.0.2 h1:V2pzMUfyVv29vf6q5RVLuPIp8PAcnLYcBcH9bzoMDLY=
 sigs.k8s.io/cluster-api v1.0.2/go.mod h1:/LkJXtsvhxTV4U0z1Y2Y1Gr2xebJ0/ce09Ab2M0XU/U=
-sigs.k8s.io/cluster-api-provider-openstack v0.5.1-0.20220113110629-19889578bf84 h1:P+D8AH4RQf1sI6KvOdcqAerjlroIctstTcxrzjtRfL0=
-sigs.k8s.io/cluster-api-provider-openstack v0.5.1-0.20220113110629-19889578bf84/go.mod h1:DjUUwFBscjYRihaHOXVMtNlBBazsstagsGO72TrqUik=
 sigs.k8s.io/cluster-api/test v1.0.1-0.20211028151834-d72fd59c8483/go.mod h1:NISRUeCxvEa6qUhVtfWt0t/C9ljTzGT9joft0YeN+3s=
 sigs.k8s.io/controller-runtime v0.10.3-0.20211011182302-43ea648ec318/go.mod h1:CQp8eyUQZ/Q7PJvnIrB6/hgfTC1kBkGylwsLgOQi1WY=
 sigs.k8s.io/controller-runtime v0.10.3/go.mod h1:CQp8eyUQZ/Q7PJvnIrB6/hgfTC1kBkGylwsLgOQi1WY=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -763,7 +763,7 @@ sigs.k8s.io/cluster-api/errors
 sigs.k8s.io/cluster-api/feature
 sigs.k8s.io/cluster-api/util
 sigs.k8s.io/cluster-api/util/version
-# sigs.k8s.io/cluster-api-provider-openstack v0.5.1-0.20220113110629-19889578bf84
+# sigs.k8s.io/cluster-api-provider-openstack v0.5.1-0.20220113110629-19889578bf84 => github.com/openshift/cluster-api-provider-openstack v0.5.1-0.20220113110629-19889578bf84
 ## explicit; go 1.16
 sigs.k8s.io/cluster-api-provider-openstack/api/v1beta1
 sigs.k8s.io/cluster-api-provider-openstack/pkg/cloud/services/compute
@@ -917,3 +917,4 @@ sigs.k8s.io/structured-merge-diff/v4/value
 ## explicit; go 1.12
 sigs.k8s.io/yaml
 # sigs.k8s.io/cluster-api => sigs.k8s.io/cluster-api v1.0.2
+# sigs.k8s.io/cluster-api-provider-openstack => github.com/openshift/cluster-api-provider-openstack v0.5.1-0.20220113110629-19889578bf84


### PR DESCRIPTION
Set a replacement in go.mod from kubernetes-sigs to openshift for
sigs.k8s.io/cluster-api-provider-openstack

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
