### PR TITLE
Add Profile and Trunks to Ports and Networks

### DIFF
--- a/pkg/apis/openstackproviderconfig/v1alpha1/types.go
+++ b/pkg/apis/openstackproviderconfig/v1alpha1/types.go
@@ -135,8 +135,9 @@ type NetworkParam struct {
 	// NoAllowedAddressPairs disables creation of allowed address pairs for the network ports
 	NoAllowedAddressPairs bool `json:"noAllowedAddressPairs,omitempty"`
 	// PortTags allows users to specify a list of tags to add to ports created in a given network
-	PortTags []string `json:"portTags,omitempty"`
-	VNICType string   `json:"vnicType,omitempty"`
+	PortTags []string          `json:"portTags,omitempty"`
+	VNICType string            `json:"vnicType,omitempty"`
+	Profile  map[string]string `json:"profile,omitempty"`
 	// PortSecurity optionally enables or disables security on ports managed by OpenStack
 	PortSecurity *bool `json:"portSecurity,omitempty"`
 }
@@ -218,9 +219,17 @@ type PortOpts struct {
 	// neutron port.
 	VNICType string `json:"vnicType,omitempty"`
 
+	// A dictionary that enables the application running on the specified
+	// host to pass and receive virtual network interface (VIF) port-specific
+	// information to the plug-in.
+	Profile map[string]string `json:"profile,omitempty"`
+
 	// enable or disable security on a given port
 	// incompatible with securityGroups and allowedAddressPairs
 	PortSecurity *bool `json:"portSecurity,omitempty"`
+
+	// Enables and disables trunk at port level. If not provided, openStackMachine.Spec.Trunk is inherited.
+	Trunk *bool `json:"trunk,omitempty"`
 }
 
 type AddressPair struct {

--- a/pkg/machine/convert.go
+++ b/pkg/machine/convert.go
@@ -159,6 +159,7 @@ func networkParamToCapov1PortOpt(net *openstackconfigv1.NetworkParam, apiVIP, in
 				VNICType:            net.VNICType,
 				FixedIPs:            fixedIP,
 				Tags:                portTags,
+				Profile:             net.Profile,
 			}
 
 			// Fetch the UUID of the network subnet is attached to or the conversion will fail
@@ -307,6 +308,8 @@ func MachineToInstanceSpec(machine *machinev1.Machine, apiVIP, ingressVIP, userD
 			AllowedAddressPairs: make([]capov1.AddressPair, len(port.AllowedAddressPairs)),
 			HostID:              port.HostID,
 			VNICType:            port.VNICType,
+			Profile:             port.Profile,
+			Trunk:               port.Trunk,
 		}
 
 		for fixedIPindex, fixedIP := range port.FixedIPs {


### PR DESCRIPTION
Seems like these options got added in late CAPO and we haven't copied
them to MAPO. So this commit adds them again.