### PR TITLE
machine/convert: reverse machineSpec.Ports order

### DIFF
--- a/pkg/machine/convert.go
+++ b/pkg/machine/convert.go
@@ -353,7 +353,9 @@ func providerSpecToMachineSpec(ps *openstackconfigv1.OpenstackProviderSpec, apiV
 		portList = append(portList, ports...)
 	}
 
-	machineSpec.Ports = append(machineSpec.Ports, portList...)
+	// The order of the networks is important, first network is the one that will be used for kubelet when
+	// the legacy cloud provider is used. Once we switch to using CCM by default, the order won't matter.
+	machineSpec.Ports = append(portList, machineSpec.Ports...)
 
 	return machineSpec, nil
 }


### PR DESCRIPTION
When building the `machineSpec.Ports` parameter, we need to take in
account the networks first, and then the additional ports.

The reason is that when using the legacy cloud provider, the main
interface (from a Nova standpoint) will be used to bind the kubelet
process and this changes when using the new cloud provider with CCM.
