### PR TITLE
Depend on CAPO v0.6.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -119,5 +119,5 @@ require (
 
 replace (
 	sigs.k8s.io/cluster-api => sigs.k8s.io/cluster-api v1.1.3
-	sigs.k8s.io/cluster-api-provider-openstack => github.com/openshift/cluster-api-provider-openstack v0.5.1-0.20220908134637-ef44b7e10a92
+	sigs.k8s.io/cluster-api-provider-openstack => github.com/openshift/cluster-api-provider-openstack v0.6.3
 )

--- a/go.sum
+++ b/go.sum
@@ -409,8 +409,8 @@ github.com/openshift/api v0.0.0-20220907152121-48d78630feb3 h1:7y9VOklNufIkJ8pQp
 github.com/openshift/api v0.0.0-20220907152121-48d78630feb3/go.mod h1:9JWn+H7X8wEPPc9D63krigXl8r3F1Mt6/lC98brUyhQ=
 github.com/openshift/client-go v0.0.0-20220905192401-849f725bff84 h1:gYG9iZHamA68gvKynYAdFNPCIduKpDNE2fOunGR1hH8=
 github.com/openshift/client-go v0.0.0-20220905192401-849f725bff84/go.mod h1:7JJKW++yzjdBscli7ToB4Ln5HQOhkvB9po3uNFcsP34=
-github.com/openshift/cluster-api-provider-openstack v0.5.1-0.20220908134637-ef44b7e10a92 h1:6pyGcRU8kRGMyaQ91unEiW2B9hIMdKF2nEO/qs4SL7A=
-github.com/openshift/cluster-api-provider-openstack v0.5.1-0.20220908134637-ef44b7e10a92/go.mod h1:ORxUwbGNFTyhP7j0/eckHxvnu11vg9DCpbot+zSzTI4=
+github.com/openshift/cluster-api-provider-openstack v0.6.3 h1:+WLBmYsVYLIirJSbyrZcBggYmAhRgLb2zmBF7mkiTA0=
+github.com/openshift/cluster-api-provider-openstack v0.6.3/go.mod h1:ORxUwbGNFTyhP7j0/eckHxvnu11vg9DCpbot+zSzTI4=
 github.com/openshift/library-go v0.0.0-20220525173854-9b950a41acdc h1:j+upvKc1uLzuL+q/JXie8+IMohOooTCaEC9w+4d1Ztk=
 github.com/openshift/library-go v0.0.0-20220525173854-9b950a41acdc/go.mod h1:AMZwYwSdbvALDl3QobEzcJ2IeDO7DYLsr42izKzh524=
 github.com/openshift/machine-api-operator v0.2.1-0.20220905154315-25dae44130fc h1:e5vDhbymlf8844PRd9Pknoqdm13nuLAIs3wYWmUMzUg=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -804,7 +804,7 @@ sigs.k8s.io/cluster-api/feature
 sigs.k8s.io/cluster-api/util
 sigs.k8s.io/cluster-api/util/annotations
 sigs.k8s.io/cluster-api/util/version
-# sigs.k8s.io/cluster-api-provider-openstack v0.6.3 => github.com/openshift/cluster-api-provider-openstack v0.5.1-0.20220908134637-ef44b7e10a92
+# sigs.k8s.io/cluster-api-provider-openstack v0.6.3 => github.com/openshift/cluster-api-provider-openstack v0.6.3
 ## explicit; go 1.17
 sigs.k8s.io/cluster-api-provider-openstack/api/v1alpha5
 sigs.k8s.io/cluster-api-provider-openstack/pkg/cloud/services/compute
@@ -960,4 +960,4 @@ sigs.k8s.io/structured-merge-diff/v4/value
 ## explicit; go 1.12
 sigs.k8s.io/yaml
 # sigs.k8s.io/cluster-api => sigs.k8s.io/cluster-api v1.1.3
-# sigs.k8s.io/cluster-api-provider-openstack => github.com/openshift/cluster-api-provider-openstack v0.5.1-0.20220908134637-ef44b7e10a92
+# sigs.k8s.io/cluster-api-provider-openstack => github.com/openshift/cluster-api-provider-openstack v0.6.3


### PR DESCRIPTION
Which is the same commit as before, just more explicit with a tag.