### PR TITLE
Add support for external LB

### DIFF
--- a/pkg/machine/actuator.go
+++ b/pkg/machine/actuator.go
@@ -142,11 +142,19 @@ func (oc *OpenstackClient) convertMachineToCapoInstanceSpec(osc *openStackContex
 		return nil, maoMachine.InvalidMachineConfiguration("error creating bootstrap for %s: %v", machine.Name, err)
 	}
 
+	var apiVip, ingressVip string
+	if clusterInfra.Status.PlatformStatus.OpenStack != nil && clusterInfra.Status.PlatformStatus.OpenStack.APIServerInternalIP != "" {
+		apiVip = clusterInfra.Status.PlatformStatus.OpenStack.APIServerInternalIP
+	}
+	if clusterInfra.Status.PlatformStatus.OpenStack != nil && clusterInfra.Status.PlatformStatus.OpenStack.IngressIP != "" {
+		ingressVip = clusterInfra.Status.PlatformStatus.OpenStack.IngressIP
+	}
+
 	// Convert to CAPO InstanceSpec
 	instanceSpec, err := MachineToInstanceSpec(
 		machine,
-		clusterInfra.Status.PlatformStatus.OpenStack.APIServerInternalIP,
-		clusterInfra.Status.PlatformStatus.OpenStack.IngressIP,
+		apiVip,
+		ingressVip,
 		userDataRendered, networkService, instanceService,
 	)
 	if err != nil {

--- a/pkg/machine/convert.go
+++ b/pkg/machine/convert.go
@@ -46,16 +46,17 @@ func getNetworkID(filter *machinev1alpha1.SubnetFilter, networkService *networki
 // Converts NetworkParams to capov1 portOpts
 func networkParamToCapov1PortOpt(net *machinev1alpha1.NetworkParam, apiVIP, ingressVIP string, trunk *bool, networkService *networking.Service) ([]capov1.PortOpts, error) {
 	ports := []capov1.PortOpts{}
+
 	addressPairs := []capov1.AddressPair{}
-	if !net.NoAllowedAddressPairs {
-		addressPairs = []capov1.AddressPair{
-			{
-				IPAddress: apiVIP,
-			},
-			{
-				IPAddress: ingressVIP,
-			},
-		}
+	if !net.NoAllowedAddressPairs && apiVIP != "" {
+		addressPairs = append(addressPairs, capov1.AddressPair{
+			IPAddress: apiVIP,
+		})
+	}
+	if !net.NoAllowedAddressPairs && ingressVIP != "" {
+		addressPairs = append(addressPairs, capov1.AddressPair{
+			IPAddress: ingressVIP,
+		})
 	}
 
 	// Flip the value of port security if not nil


### PR DESCRIPTION
Allowed Address Pairs won't be configured if API VIP and Ingress VIP are
empty (not set in the PlatformStatus, when external LB is used).
