### PR TITLE
OSASINFRA-3075 - Add support for external LB

### DIFF
--- a/pkg/machine/actuator.go
+++ b/pkg/machine/actuator.go
@@ -142,11 +142,19 @@ func (oc *OpenstackClient) convertMachineToCapoInstanceSpec(osc *openStackContex
 		return nil, maoMachine.InvalidMachineConfiguration("error creating bootstrap for %s: %v", machine.Name, err)
 	}
 
+	var apiVip, ingressVip string
+	if clusterInfra.Status.PlatformStatus.OpenStack != nil && clusterInfra.Status.PlatformStatus.OpenStack.APIServerInternalIP != "" {
+		apiVip = clusterInfra.Status.PlatformStatus.OpenStack.APIServerInternalIP
+	}
+	if clusterInfra.Status.PlatformStatus.OpenStack != nil && clusterInfra.Status.PlatformStatus.OpenStack.IngressIP != "" {
+		ingressVip = clusterInfra.Status.PlatformStatus.OpenStack.IngressIP
+	}
+
 	// Convert to CAPO InstanceSpec
 	instanceSpec, err := MachineToInstanceSpec(
 		machine,
-		clusterInfra.Status.PlatformStatus.OpenStack.APIServerInternalIP,
-		clusterInfra.Status.PlatformStatus.OpenStack.IngressIP,
+		apiVip,
+		ingressVip,
 		userDataRendered, networkService, instanceService,
 	)
 	if err != nil {


### PR DESCRIPTION
Allowed Address Pairs won't be configured if API VIP and Ingress VIP are empty (not set in the PlatformStatus, when external LB is used).