### PR TITLE
Add dual stack API and Ingress VIPs support

### DIFF
--- a/pkg/machine/actuator.go
+++ b/pkg/machine/actuator.go
@@ -153,8 +153,8 @@ func (oc *OpenstackClient) convertMachineToCapoInstanceSpec(osc *openStackContex
 	// Convert to CAPO InstanceSpec
 	instanceSpec, err := MachineToInstanceSpec(
 		machine,
-		clusterInfra.Status.PlatformStatus.OpenStack.APIServerInternalIP,
-		clusterInfra.Status.PlatformStatus.OpenStack.IngressIP,
+		clusterInfra.Status.PlatformStatus.OpenStack.APIServerInternalIPs,
+		clusterInfra.Status.PlatformStatus.OpenStack.IngressIPs,
 		userDataRendered, networkService, instanceService,
 		ignoreAddressPairs,
 	)


### PR DESCRIPTION
The installer started supporting multiple VIPs for API and ingress in OpenShift 4.12[1].
This commit adds support to use multiple VIPs instead of only one when defining the
allowed-address-pairs in the Servers Ports.

[1] https://github.com/openshift/installer/pull/5798

