### PR TITLE
Bug OCPBUGS-4629: Set controller's SyncPeriod to 1 hour

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -47,6 +47,7 @@ var (
 	leaseDuration = 120 * time.Second
 	renewDeadline = 110 * time.Second
 	retryPeriod   = 20 * time.Second
+	syncPeriod    = 1 * time.Hour
 )
 
 func main() {
@@ -107,6 +108,7 @@ func main() {
 		// Slow the default retry and renew election rate to reduce etcd writes at idle: BZ 1858400
 		RetryPeriod:   &retryPeriod,
 		RenewDeadline: &renewDeadline,
+		SyncPeriod:    &syncPeriod,
 	}
 	if *watchNamespace != "" {
 		opts.Namespace = *watchNamespace


### PR DESCRIPTION
The Machine controller that we run doesn't set the SyncPeriod. This means that Machine objects are not periodically reconciled with the status of them in OpenStack.

This is a problem when the user adds a floating IP to a Server manually. In such case cloud-provider-openstack will notice it and update the Node object accordingly. This will cause Kubelet to generate a new CSR with updated SANs including new FIP address. Then cluster-machine-approver will compare the list of SANs from the CSR with Machine's Status.Addresses and will never find the FIP failing the approval.

This commit sets SyncPeriod of the controller to 1 hour in order to make sure Machines are periodically reconciled with the state of the instances in OpenStack just like Nodes are.