### PR TITLE
Configure User Agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,4 +136,4 @@ zz_generated.openapi.go
 
 # binaries
 /bin
-/machine-controller
+/machine-controller-manager

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,14 @@
+SHELL := bash
+
 TESTARGS_DEFAULT := "-v"
 export TESTARGS ?= $(TESTARGS_DEFAULT)
 
 HAS_LINT := $(shell command -v golint;)
 
 GOOS ?= $(shell go env GOOS)
-VERSION ?= $(shell git describe --exact-match 2> /dev/null || \
-                 git describe --match=$(git rev-parse --short=8 HEAD) --always --dirty --abbrev=8)
 GOFLAGS   :=
 TAGS      :=
-LDFLAGS   := "-w -s -X 'main.version=${VERSION}'"
+LDFLAGS := $(shell source ./hack/version.sh; version::ldflags)
 REGISTRY ?= k8scloudprovider
 
 # CTI targets
@@ -17,7 +17,7 @@ build: manager
 
 manager:
 	CGO_ENABLED=0 GOOS=$(GOOS) go build \
-		-ldflags $(LDFLAGS) \
+		-ldflags "${LDFLAGS}" \
 		-o machine-controller-manager \
 		cmd/manager/main.go
 

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -18,12 +18,14 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"log"
 	"os"
 	"time"
 
 	"github.com/openshift/machine-api-provider-openstack/pkg/machine"
 	"github.com/openshift/machine-api-provider-openstack/pkg/machineset"
+	"github.com/openshift/machine-api-provider-openstack/version"
 
 	configv1 "github.com/openshift/api/config/v1"
 	machinev1alpha1 "github.com/openshift/api/machine/v1alpha1"
@@ -87,8 +89,20 @@ func main() {
 		"Address for hosting metrics",
 	)
 
+	showVersion := flag.Bool(
+		"version",
+		false,
+		"Show current version",
+	)
+
 	klog.InitFlags(nil)
 	flag.Parse()
+
+	if *showVersion {
+		fmt.Println(version.Get())
+		fmt.Println(version.Get().GitCommit)
+		os.Exit(0)
+	}
 
 	// Get a config to talk to the apiserver
 	cfg, err := config.GetConfig()

--- a/hack/version.sh
+++ b/hack/version.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# 	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+version::get_version_vars() {
+    # shellcheck disable=SC1083
+    GIT_COMMIT="$(git rev-parse HEAD^{commit})"
+
+    if git_status=$(git status --porcelain 2>/dev/null) && [[ -z ${git_status} ]]; then
+        GIT_TREE_STATE="clean"
+    else
+        GIT_TREE_STATE="dirty"
+    fi
+}
+
+# stolen from k8s.io/hack/lib/version.sh and modified
+# Prints the value that needs to be passed to the -ldflags parameter of go build
+version::ldflags() {
+    version::get_version_vars
+
+    local -a ldflags
+    function add_ldflag() {
+        local key=${1}
+        local val=${2}
+        ldflags+=(
+            "-X 'github.com/openshift/machine-api-provider-openstack/version.${key}=${val}'"
+        )
+    }
+
+    add_ldflag "buildDate" "$(date ${SOURCE_DATE_EPOCH:+"--date=@${SOURCE_DATE_EPOCH}"} -u +'%Y-%m-%dT%H:%M:%SZ')"
+    add_ldflag "gitCommit" "${GIT_COMMIT}"
+    add_ldflag "gitTreeState" "${GIT_TREE_STATE}"
+
+  # The -ldflags parameter takes a single string, so join the output.
+  echo "${ldflags[*]-}"
+}
+
+version::ldflags

--- a/pkg/clients/machineservice.go
+++ b/pkg/clients/machineservice.go
@@ -58,7 +58,7 @@ func NewInstanceServiceFromCloud(cloud clientconfig.Cloud, cert []byte) (*Instan
 		return nil, err
 	}
 
-	serverClient, err := openstack.NewComputeV2(provider, gophercloud.EndpointOpts{
+	computeClient, err := openstack.NewComputeV2(provider, gophercloud.EndpointOpts{
 		Region: cloud.RegionName,
 	})
 	if err != nil {
@@ -73,7 +73,7 @@ func NewInstanceServiceFromCloud(cloud clientconfig.Cloud, cert []byte) (*Instan
 	}
 
 	return &InstanceService{
-		computeClient: serverClient,
+		computeClient: computeClient,
 		imagesClient:  imagesClient,
 	}, nil
 }

--- a/pkg/clients/utils.go
+++ b/pkg/clients/utils.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gophercloud/utils/openstack/clientconfig"
 	machinev1alpha1 "github.com/openshift/api/machine/v1alpha1"
 	machinev1 "github.com/openshift/api/machine/v1beta1"
+	"github.com/openshift/machine-api-provider-openstack/version"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
@@ -85,6 +86,11 @@ func GetProviderClient(cloud clientconfig.Cloud, cert []byte) (*gophercloud.Prov
 	if err != nil {
 		return nil, fmt.Errorf("Create new provider client failed: %v", err)
 	}
+
+	// we represent version using commits since we don't tag releases
+	ua := gophercloud.UserAgent{}
+	ua.Prepend(fmt.Sprintf("machine-api-provider-openstack/%s", version.Get().GitCommit))
+	provider.UserAgent = ua
 
 	if cert != nil {
 		certPool, err := x509.SystemCertPool()

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+import (
+	"fmt"
+	"runtime"
+)
+
+var (
+	gitCommit    string // sha1 from git, output of $(git rev-parse HEAD)
+	gitTreeState string // state of git tree, either "clean" or "dirty"
+	buildDate    string // build date in ISO8601 format, output of $(date -u +'%Y-%m-%dT%H:%M:%SZ')
+)
+
+type Info struct {
+	GitCommit    string `json:"gitCommit,omitempty"`
+	GitTreeState string `json:"gitTreeState,omitempty"`
+	BuildDate    string `json:"buildDate,omitempty"`
+	GoVersion    string `json:"goVersion,omitempty"`
+	Compiler     string `json:"compiler,omitempty"`
+	Platform     string `json:"platform,omitempty"`
+}
+
+func Get() Info {
+	return Info{
+		GitCommit:    gitCommit,
+		GitTreeState: gitTreeState,
+		BuildDate:    buildDate,
+		GoVersion:    runtime.Version(),
+		Compiler:     runtime.Compiler,
+		Platform:     fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+	}
+}


### PR DESCRIPTION
This can be a helpful breadcrumb when debugging services.

> **Note**
> Unlike https://github.com/openshift/openstack-cinder-csi-driver-operator/pull/123 and
> https://github.com/openshift/csi-driver-manila-operator/pull/191, we need to
> create the `version` package here and modify our `Makefile` to configure
> correct version attributes.
