### PR TITLE
Rework how we build the container image

### DIFF
--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,9 +1,7 @@
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.14 AS builder
 WORKDIR /go/src/sigs.k8s.io/cluster-api-provider-openstack
 COPY . .
-
-RUN go build -o ./machine-controller-manager ./cmd/manager
+RUN make
 
 FROM registry.ci.openshift.org/ocp/4.14:base
-
 COPY --from=builder /go/src/sigs.k8s.io/cluster-api-provider-openstack/machine-controller-manager /

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ build: manager
 manager:
 	CGO_ENABLED=0 GOOS=$(GOOS) go build \
 		-ldflags $(LDFLAGS) \
-		-o bin/manager \
+		-o machine-controller-manager \
 		cmd/manager/main.go
 
 


### PR DESCRIPTION
Aligns our Dockerfile with image building best practices by using make to build our binaries. This necessitates a small change to the Makefile itself to align binary names.

Signed-off-by: Stephen Finucane <stephenfin@redhat.com>
