### PR TITLE
Bump CAPO to match branch release-0.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -117,5 +117,5 @@ require (
 replace (
 	github.com/elazarl/goproxy => github.com/elazarl/goproxy v0.0.0-20230731152917-f99041a5c027
 	sigs.k8s.io/cluster-api => sigs.k8s.io/cluster-api v1.3.0-rc.0.0.20230131103650-2c89700e11b0
-	sigs.k8s.io/cluster-api-provider-openstack => github.com/openshift/cluster-api-provider-openstack v0.7.2
+	sigs.k8s.io/cluster-api-provider-openstack => github.com/openshift/cluster-api-provider-openstack v0.7.3-0.20230814121631-021041b47806
 )

--- a/go.sum
+++ b/go.sum
@@ -300,8 +300,8 @@ github.com/openshift/api v0.0.0-20230208193339-068b2ae5534f h1:+GaTEfR8gYzh64fdl
 github.com/openshift/api v0.0.0-20230208193339-068b2ae5534f/go.mod h1:ctXNyWanKEjGj8sss1KjjHQ3ENKFm33FFnS5BKaIPh4=
 github.com/openshift/client-go v0.0.0-20220905192401-849f725bff84 h1:gYG9iZHamA68gvKynYAdFNPCIduKpDNE2fOunGR1hH8=
 github.com/openshift/client-go v0.0.0-20220905192401-849f725bff84/go.mod h1:7JJKW++yzjdBscli7ToB4Ln5HQOhkvB9po3uNFcsP34=
-github.com/openshift/cluster-api-provider-openstack v0.7.2 h1:XDiXwT69Ynji+XyQNdP2ixWzzGfLvMbnrCADnShACwY=
-github.com/openshift/cluster-api-provider-openstack v0.7.2/go.mod h1:/hp/GE58MGbxSRErYBx/PJj5+bxgWexJAzLqho+HZR4=
+github.com/openshift/cluster-api-provider-openstack v0.7.3-0.20230814121631-021041b47806 h1:hD90gpdj5YR+P6k2xf/oIcMVldqauCgZ1xeBb2DGjxM=
+github.com/openshift/cluster-api-provider-openstack v0.7.3-0.20230814121631-021041b47806/go.mod h1:/hp/GE58MGbxSRErYBx/PJj5+bxgWexJAzLqho+HZR4=
 github.com/openshift/library-go v0.0.0-20220525173854-9b950a41acdc h1:j+upvKc1uLzuL+q/JXie8+IMohOooTCaEC9w+4d1Ztk=
 github.com/openshift/library-go v0.0.0-20220525173854-9b950a41acdc/go.mod h1:AMZwYwSdbvALDl3QobEzcJ2IeDO7DYLsr42izKzh524=
 github.com/openshift/machine-api-operator v0.2.1-0.20220905154315-25dae44130fc h1:e5vDhbymlf8844PRd9Pknoqdm13nuLAIs3wYWmUMzUg=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -817,7 +817,7 @@ sigs.k8s.io/cluster-api/util/annotations
 sigs.k8s.io/cluster-api/util/contract
 sigs.k8s.io/cluster-api/util/topology
 sigs.k8s.io/cluster-api/util/version
-# sigs.k8s.io/cluster-api-provider-openstack v0.6.3 => github.com/openshift/cluster-api-provider-openstack v0.7.2
+# sigs.k8s.io/cluster-api-provider-openstack v0.6.3 => github.com/openshift/cluster-api-provider-openstack v0.7.3-0.20230814121631-021041b47806
 ## explicit; go 1.19
 sigs.k8s.io/cluster-api-provider-openstack/api/v1alpha6
 sigs.k8s.io/cluster-api-provider-openstack/pkg/clients
@@ -977,4 +977,4 @@ sigs.k8s.io/structured-merge-diff/v4/value
 sigs.k8s.io/yaml
 # github.com/elazarl/goproxy => github.com/elazarl/goproxy v0.0.0-20230731152917-f99041a5c027
 # sigs.k8s.io/cluster-api => sigs.k8s.io/cluster-api v1.3.0-rc.0.0.20230131103650-2c89700e11b0
-# sigs.k8s.io/cluster-api-provider-openstack => github.com/openshift/cluster-api-provider-openstack v0.7.2
+# sigs.k8s.io/cluster-api-provider-openstack => github.com/openshift/cluster-api-provider-openstack v0.7.3-0.20230814121631-021041b47806

--- a/vendor/sigs.k8s.io/cluster-api-provider-openstack/pkg/cloud/services/compute/instance_types.go
+++ b/vendor/sigs.k8s.io/cluster-api-provider-openstack/pkg/cloud/services/compute/instance_types.go
@@ -152,15 +152,9 @@ func (is *InstanceStatus) NetworkStatus() (*InstanceNetworkStatus, error) {
 			return nil, fmt.Errorf("error unmarshalling addresses for instance %s: %w", is.ID(), err)
 		}
 
-		var addresses []corev1.NodeAddress
+		var IPv4addresses, IPv6addresses []corev1.NodeAddress
 		for i := range interfaceList {
 			address := &interfaceList[i]
-
-			// Only consider IPv4
-			if address.Version != 4 {
-				is.logger.V(6).Info("Ignoring IP address: only IPv4 is supported", "version", address.Version, "address", address.Address)
-				continue
-			}
 
 			var addressType corev1.NodeAddressType
 			switch address.Type {
@@ -172,14 +166,20 @@ func (is *InstanceStatus) NetworkStatus() (*InstanceNetworkStatus, error) {
 				is.logger.V(6).Info("Ignoring address with unknown type", "address", address.Address, "type", address.Type)
 				continue
 			}
-
-			addresses = append(addresses, corev1.NodeAddress{
-				Type:    addressType,
-				Address: address.Address,
-			})
+			if address.Version == 4 {
+				IPv4addresses = append(IPv4addresses, corev1.NodeAddress{
+					Type:    addressType,
+					Address: address.Address,
+				})
+			} else {
+				IPv6addresses = append(IPv6addresses, corev1.NodeAddress{
+					Type:    addressType,
+					Address: address.Address,
+				})
+			}
 		}
-
-		addressesByNetwork[networkName] = addresses
+		// Maintain IPv4 addresses being first ones on Machine's status given there are operations, e.g. reconcile load-balancer member, that use the first address by network type
+		addressesByNetwork[networkName] = append(IPv4addresses, IPv6addresses...)
 	}
 
 	return &InstanceNetworkStatus{addressesByNetwork}, nil


### PR DESCRIPTION
Sync CAPO dependency with the content of release-0.7 to include a fix needed for dual-stack installs.

Commands that were run `go mod tidy` and `go mod vendor`.