### PR TITLE
Update OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,6 +2,7 @@
 
 approvers:
   - shiftstack-team
+  - cloud-team
 reviewers:
   - shiftstack-team
 component: "Cloud Compute"

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -3,7 +3,18 @@
 aliases:
   shiftstack-team:
     - EmilienM
+    - MaysaMacedo
+    - dulek
+    - gryf
     - mandre
     - mdbooth
     - pierreprinetti
     - stephenfin
+
+  cloud-team:
+    - JoelSpeed
+    - RadekManak
+    - damdo
+    - elmiko
+    - odvarkadaniel
+    - nrb


### PR DESCRIPTION
Not all ShiftStack team members were having approval rights. Moreover I added cloud team as a backup, similarly to how it's done in cloud-provider-openstack.