### PR TITLE
OCPBUGS-16597: Don't build InstanceSpec during delete operations

### DIFF
--- a/pkg/machine/actuator.go
+++ b/pkg/machine/actuator.go
@@ -125,7 +125,7 @@ func getInstanceStatus(scope scope.Scope, machine *machinev1.Machine) (*compute.
 }
 
 func (oc *OpenstackClient) convertMachineToCapoInstanceSpec(scope scope.Scope, machine *machinev1.Machine) (*compute.InstanceSpec, error) {
-	providerSpec, err := clients.MachineSpecFromProviderSpec(machine.Spec.ProviderSpec)
+	machineSpec, err := clients.MachineSpecFromProviderSpec(machine.Spec.ProviderSpec)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate MachineSpec object: %v", err)
 	}
@@ -145,7 +145,7 @@ func (oc *OpenstackClient) convertMachineToCapoInstanceSpec(scope scope.Scope, m
 		return nil, err
 	}
 
-	userDataRendered, err := oc.getUserData(machine, providerSpec, oc.params.KubeClient)
+	userDataRendered, err := oc.getUserData(machine, machineSpec, oc.params.KubeClient)
 	if err != nil {
 		return nil, maoMachine.InvalidMachineConfiguration("error creating bootstrap for %s: %v", machine.Name, err)
 	}
@@ -181,7 +181,7 @@ func (oc *OpenstackClient) Update(ctx context.Context, machine *machinev1.Machin
 }
 
 func (oc *OpenstackClient) reconcile(ctx context.Context, machine *machinev1.Machine) error {
-	providerSpec, err := clients.MachineSpecFromProviderSpec(machine.Spec.ProviderSpec)
+	machineSpec, err := clients.MachineSpecFromProviderSpec(machine.Spec.ProviderSpec)
 	if err != nil {
 		return maoMachine.InvalidMachineConfiguration("Cannot unmarshal providerSpec for %s: %v", machine.Name, err)
 	}
@@ -217,13 +217,13 @@ func (oc *OpenstackClient) reconcile(ctx context.Context, machine *machinev1.Mac
 		return fmt.Errorf("error setting provider ID for %q: %w", machine.Name, err)
 	}
 
-	if err := reconcileFloatingIP(machine, providerSpec, instanceStatus, scope); err != nil {
+	if err := reconcileFloatingIP(machine, machineSpec, instanceStatus, scope); err != nil {
 		return err
 	}
 
 	// Apply labels and annotations and patch the machine object
 	patch := client.MergeFrom(machine.DeepCopy())
-	setMachineLabels(machine, regionName, instanceStatus.AvailabilityZone(), providerSpec.Flavor)
+	setMachineLabels(machine, regionName, instanceStatus.AvailabilityZone(), machineSpec.Flavor)
 	setMachineAnnotations(machine, instanceStatus)
 	if err := oc.client.Patch(ctx, machine, patch); err != nil {
 		return err
@@ -267,8 +267,8 @@ func (oc *OpenstackClient) createInstance(ctx context.Context, machine *machinev
 	return instanceStatus, nil
 }
 
-func reconcileFloatingIP(machine *machinev1.Machine, providerSpec *machinev1alpha1.OpenstackProviderSpec, instanceStatus *compute.InstanceStatus, scope scope.Scope) error {
-	if providerSpec.FloatingIP == "" {
+func reconcileFloatingIP(machine *machinev1.Machine, machineSpec *machinev1alpha1.OpenstackProviderSpec, instanceStatus *compute.InstanceStatus, scope scope.Scope) error {
+	if machineSpec.FloatingIP == "" {
 		return nil
 	}
 
@@ -279,7 +279,7 @@ func reconcileFloatingIP(machine *machinev1.Machine, providerSpec *machinev1alph
 
 	// Look for the floating IP on the server
 	for _, address := range networkStatus.Addresses() {
-		if address.Type == corev1.NodeExternalIP && address.Address == providerSpec.FloatingIP {
+		if address.Type == corev1.NodeExternalIP && address.Address == machineSpec.FloatingIP {
 			return nil
 		}
 	}
@@ -289,7 +289,7 @@ func reconcileFloatingIP(machine *machinev1.Machine, providerSpec *machinev1alph
 		return err
 	}
 	var osCluster capov1.OpenStackCluster
-	fp, err := networkService.GetOrCreateFloatingIP(machine, &osCluster, utils.GetClusterNameWithNamespace(machine), providerSpec.FloatingIP)
+	fp, err := networkService.GetOrCreateFloatingIP(machine, &osCluster, utils.GetClusterNameWithNamespace(machine), machineSpec.FloatingIP)
 	if err != nil {
 		return fmt.Errorf("get floatingIP err: %v", err)
 	}
@@ -327,12 +327,12 @@ func (oc *OpenstackClient) Delete(ctx context.Context, machine *machinev1.Machin
 		return err
 	}
 
-	providerSpec, err := clients.MachineSpecFromProviderSpec(machine.Spec.ProviderSpec)
+	machineSpec, err := clients.MachineSpecFromProviderSpec(machine.Spec.ProviderSpec)
 	if err != nil {
 		return err
 	}
 	// Create a minimal instancespec since we don't want to reparse and reconstruct all the networking info just to delete
-	rootVolume, _ := extractRootVolumeFromProviderSpec(providerSpec)
+	rootVolume, _ := extractRootVolumeFromProviderSpec(machineSpec)
 	instanceSpec := compute.InstanceSpec{
 		Ports:      make([]capov1.PortOpts, 0, 0),
 		RootVolume: rootVolume,

--- a/pkg/machine/convert.go
+++ b/pkg/machine/convert.go
@@ -194,12 +194,32 @@ func networkParamToCapov1PortOpt(net *machinev1alpha1.NetworkParam, apiVIPs, ing
 	return ports, nil
 }
 
-func injectDefaultTags(instanceSpec *compute.InstanceSpec, machine *machinev1beta1.Machine) {
+func extractDefaultTags(machine *machinev1beta1.Machine) []string {
 	defaultTags := []string{
 		"cluster-api-provider-openstack",
 		utils.GetClusterNameWithNamespace(machine),
 	}
-	instanceSpec.Tags = append(instanceSpec.Tags, defaultTags...)
+	return defaultTags
+}
+
+// extractRootVolumeFromProviderSpec extracts pertinent root volume information from a provider spec
+func extractRootVolumeFromProviderSpec(providerSpec *machinev1alpha1.OpenstackProviderSpec) (*capov1.RootVolume, string) {
+	var rootVolume *capov1.RootVolume
+	var image string
+
+	rootVolume = &capov1.RootVolume{
+		Size:             providerSpec.RootVolume.Size,
+		VolumeType:       providerSpec.RootVolume.VolumeType,
+		AvailabilityZone: providerSpec.RootVolume.Zone,
+	}
+
+	// TODO(dulek): Installer does not populate ps.Image when ps.RootVolume is set and will instead
+	//              populate ps.RootVolume.SourceUUID. Moreover, according to the ClusterOSImage
+	//              option definition this is always the name of the image and never the UUID.
+	//              We should allow UUID at some point and this will need an update.
+	image = providerSpec.RootVolume.SourceUUID
+
+	return rootVolume, image
 }
 
 func securityGroupParamToCapov1SecurityGroupFilter(psSecurityGroups []machinev1alpha1.SecurityGroupParam) []capov1.SecurityGroupFilter {
@@ -274,20 +294,9 @@ func MachineToInstanceSpec(machine *machinev1beta1.Machine, apiVIPs, ingressVIPs
 		SecurityGroups: securityGroupParamToCapov1SecurityGroupFilter(ps.SecurityGroups),
 	}
 
-	injectDefaultTags(&instanceSpec, machine)
-
+	instanceSpec.Tags = append(instanceSpec.Tags, extractDefaultTags(machine)...)
 	if ps.RootVolume != nil {
-		instanceSpec.RootVolume = &capov1.RootVolume{
-			Size:             ps.RootVolume.Size,
-			VolumeType:       ps.RootVolume.VolumeType,
-			AvailabilityZone: ps.RootVolume.Zone,
-		}
-
-		// TODO(dulek): Installer does not populate ps.Image when ps.RootVolume is set and will instead
-		//              populate ps.RootVolume.SourceUUID. Moreover, according to the ClusterOSImage
-		//              option definition this is always the name of the image and never the UUID.
-		//              We should allow UUID at some point and this will need an update.
-		instanceSpec.Image = ps.RootVolume.SourceUUID
+		instanceSpec.RootVolume, instanceSpec.Image = extractRootVolumeFromProviderSpec(ps)
 	}
 
 	if ps.AdditionalBlockDevices != nil {

--- a/pkg/machine/convert.go
+++ b/pkg/machine/convert.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/servergroups"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/subnets"
 	machinev1alpha1 "github.com/openshift/api/machine/v1alpha1"
 	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
@@ -15,6 +16,11 @@ import (
 
 type subnetsGetter interface {
 	GetSubnetsByFilter(opts subnets.ListOptsBuilder) ([]subnets.Subnet, error)
+}
+
+type instanceService interface {
+	GetServerGroupsByName(name string) ([]servergroups.ServerGroup, error)
+	CreateServerGroup(name string) (*servergroups.ServerGroup, error)
 }
 
 // Looks up a subnet in openstack and gets the ID of the network its attached to
@@ -246,7 +252,7 @@ func portProfileToCapov1BindingProfile(portProfile map[string]string) capov1.Bin
 	return bindingProfile
 }
 
-func MachineToInstanceSpec(machine *machinev1beta1.Machine, apiVIPs, ingressVIPs []string, userData string, networkService subnetsGetter, instanceService *clients.InstanceService, ignoreAddressPairs bool) (*compute.InstanceSpec, error) {
+func MachineToInstanceSpec(machine *machinev1beta1.Machine, apiVIPs, ingressVIPs []string, userData string, networkService subnetsGetter, instanceService instanceService, ignoreAddressPairs bool) (*compute.InstanceSpec, error) {
 	ps, err := clients.MachineSpecFromProviderSpec(machine.Spec.ProviderSpec)
 	if err != nil {
 		return nil, err

--- a/pkg/machine/convert_test.go
+++ b/pkg/machine/convert_test.go
@@ -1,12 +1,17 @@
 package machine
 
 import (
+	"encoding/json"
 	"reflect"
 	"testing"
 
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/servergroups"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/subnets"
 	machinev1alpha1 "github.com/openshift/api/machine/v1alpha1"
+	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
+	"k8s.io/apimachinery/pkg/runtime"
 	capov1 "sigs.k8s.io/cluster-api-provider-openstack/api/v1alpha7"
+	"sigs.k8s.io/cluster-api-provider-openstack/pkg/cloud/services/compute"
 )
 
 type testSubnetsGetter struct{}
@@ -17,6 +22,24 @@ func (testSubnetsGetter) GetSubnetsByFilter(opts subnets.ListOptsBuilder) ([]sub
 
 func newSubnetsGetter() testSubnetsGetter {
 	return testSubnetsGetter{}
+}
+
+type testInstanceService struct{}
+
+func (testInstanceService) GetServerGroupsByName(name string) ([]servergroups.ServerGroup, error) {
+	return []servergroups.ServerGroup{}, nil
+}
+
+func (testInstanceService) CreateServerGroup(name string) (*servergroups.ServerGroup, error) {
+	servergroup := servergroups.ServerGroup{
+		Name:     "fakeServerGroup",
+		Policies: []string{"soft-anti-affinity"},
+	}
+	return &servergroup, nil
+}
+
+func newInstanceService() testInstanceService {
+	return testInstanceService{}
 }
 
 func newNetworkParam(options ...func(*machinev1alpha1.NetworkParam)) *machinev1alpha1.NetworkParam {
@@ -381,6 +404,7 @@ func TestNetworkParamToCapov1PortOpt(t *testing.T) {
 		})
 	}
 }
+
 func TestSecurityGroupsToSecurityGroupParams(t *testing.T) {
 	tests := []struct {
 		name           string
@@ -425,6 +449,154 @@ func TestSecurityGroupsToSecurityGroupParams(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := securityGroupsToSecurityGroupParams(tt.securityGroups); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("securityGroupsToSecurityGroupParams() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMachineToInstanceSpec(t *testing.T) {
+	tests := []struct {
+		name         string
+		providerSpec *machinev1alpha1.OpenstackProviderSpec
+		expected     *compute.InstanceSpec
+	}{
+		{
+			name:         "minimal",
+			providerSpec: &machinev1alpha1.OpenstackProviderSpec{},
+			expected: &compute.InstanceSpec{
+				Tags: []string{
+					"cluster-api-provider-openstack",
+					"-",
+				},
+				Ports:          []capov1.PortOpts{},
+				SecurityGroups: []capov1.SecurityGroupFilter{},
+			},
+		},
+		{
+			name: "with image",
+			providerSpec: &machinev1alpha1.OpenstackProviderSpec{
+				Image: "92f33707-6e04-4756-b470-6902f01289bb",
+			},
+			expected: &compute.InstanceSpec{
+				Image:          "92f33707-6e04-4756-b470-6902f01289bb",
+				Ports:          []capov1.PortOpts{},
+				SecurityGroups: []capov1.SecurityGroupFilter{},
+				Tags: []string{
+					"cluster-api-provider-openstack",
+					"-",
+				},
+			},
+		},
+		{
+			name: "with root volume",
+			providerSpec: &machinev1alpha1.OpenstackProviderSpec{
+				RootVolume: &machinev1alpha1.RootVolume{
+					SourceUUID: "f4dd1746-bba9-4932-be83-1b20d0a5adc9",
+					Size:       10,
+				},
+			},
+			expected: &compute.InstanceSpec{
+				Image: "f4dd1746-bba9-4932-be83-1b20d0a5adc9",
+				Ports: []capov1.PortOpts{},
+				RootVolume: &capov1.RootVolume{
+					Size:             10,
+					VolumeType:       "",
+					AvailabilityZone: "",
+				},
+				SecurityGroups: []capov1.SecurityGroupFilter{},
+				Tags: []string{
+					"cluster-api-provider-openstack",
+					"-",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bytes, err := json.Marshal(tt.providerSpec)
+			if err != nil {
+				t.Fatal("Failed to marshal provider spec")
+			}
+
+			machine := machinev1beta1.Machine{
+				Spec: machinev1beta1.MachineSpec{
+					ProviderSpec: machinev1beta1.ProviderSpec{
+						Value: &runtime.RawExtension{
+							Raw: bytes,
+						},
+					},
+				},
+			}
+			apiVIPs := []string{}
+			ingressVIPs := []string{}
+			userData := ""
+			networkService := newSubnetsGetter()
+			instanceService := newInstanceService()
+			ignoreAddressPairs := false
+
+			actual, err := MachineToInstanceSpec(
+				&machine,
+				apiVIPs,
+				ingressVIPs,
+				userData,
+				networkService,
+				instanceService,
+				ignoreAddressPairs,
+			)
+			if err != nil {
+				t.Fatalf("Expected no error, found one: %v", err)
+			}
+			if !reflect.DeepEqual(*actual, *tt.expected) {
+				t.Errorf("MachineToInstanceSpec() = %#v, want %#v", *actual, *tt.expected)
+				if !reflect.DeepEqual(actual.Name, tt.expected.Name) {
+					t.Errorf("Mismatched Name, expected %s, got %s", tt.expected.Name, actual.Name)
+				}
+				if !reflect.DeepEqual(actual.Image, tt.expected.Image) {
+					t.Errorf("Mismatched Image, expected %s, got %s", tt.expected.Image, actual.Image)
+				}
+				if !reflect.DeepEqual(actual.ImageUUID, tt.expected.ImageUUID) {
+					t.Errorf("Mismatched ImageUUID, expected %s, got %s", tt.expected.ImageUUID, actual.ImageUUID)
+				}
+				if !reflect.DeepEqual(actual.Flavor, tt.expected.Flavor) {
+					t.Errorf("Mismatched Flavor, expected %s, got %s", tt.expected.Flavor, actual.Flavor)
+				}
+				if !reflect.DeepEqual(actual.SSHKeyName, tt.expected.SSHKeyName) {
+					t.Errorf("Mismatched SSHKeyName, expected %s, got %s", tt.expected.SSHKeyName, actual.SSHKeyName)
+				}
+				if !reflect.DeepEqual(actual.UserData, tt.expected.UserData) {
+					t.Errorf("Mismatched UserData, expected %s, got %s", tt.expected.UserData, actual.UserData)
+				}
+				if !reflect.DeepEqual(actual.Metadata, tt.expected.Metadata) {
+					t.Errorf("Mismatched Metadata, expected %#v, got %#v", tt.expected.Metadata, actual.Metadata)
+				}
+				if !reflect.DeepEqual(actual.ConfigDrive, tt.expected.ConfigDrive) {
+					t.Errorf("Mismatched ConfigDrive, expected %t, got %t", tt.expected.ConfigDrive, actual.ConfigDrive)
+				}
+				if !reflect.DeepEqual(actual.FailureDomain, tt.expected.FailureDomain) {
+					t.Errorf("Mismatched FailureDomain, expected %s, got %s", tt.expected.FailureDomain, actual.FailureDomain)
+				}
+				if !reflect.DeepEqual(actual.RootVolume, tt.expected.RootVolume) {
+					t.Errorf("Mismatched RootVolume, expected %#v, got %#v", tt.expected.RootVolume, actual.RootVolume)
+				}
+				if !reflect.DeepEqual(actual.AdditionalBlockDevices, tt.expected.AdditionalBlockDevices) {
+					t.Errorf("Mismatched AdditionalBlockDevices, expected %#v, got %#v", tt.expected.AdditionalBlockDevices, actual.AdditionalBlockDevices)
+				}
+				if !reflect.DeepEqual(actual.ServerGroupID, tt.expected.ServerGroupID) {
+					t.Errorf("Mismatched ServerGroupID, expected %s, got %s", tt.expected.ServerGroupID, actual.ServerGroupID)
+				}
+				if !reflect.DeepEqual(actual.Trunk, tt.expected.Trunk) {
+					t.Errorf("Mismatched Trunk, expected %t, got %t", tt.expected.Trunk, actual.Trunk)
+				}
+				if !reflect.DeepEqual(actual.Tags, tt.expected.Tags) {
+					t.Errorf("Mismatched Tags, expected %#v, got %#v", tt.expected.Tags, actual.Tags)
+				}
+				if !reflect.DeepEqual(actual.SecurityGroups, tt.expected.SecurityGroups) {
+					t.Errorf("Mismatched SecurityGroups, expected %#v, got %#v", tt.expected.SecurityGroups, actual.SecurityGroups)
+				}
+				if !reflect.DeepEqual(actual.Ports, tt.expected.Ports) {
+					t.Errorf("Mismatched Ports, expected %#v, got %#v", tt.expected.Ports, actual.Ports)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
We were building a full `InstanceSpec` struct as part of our Delete operation before promptly throwing the bulk of it away as we only needed the root volume information.

This is wasteful as building the `InstanceSpec` involves looking up resources to resolve both identifiers (like `serverGroupName`, which must be resolved to an ID of a new or existing server group using the Compute API) and filters (such as a `networks[*].filter.subnets[*]`, which must be resolved to an ID if a network name is given).

It's also the source of bugs. This is because we currently do not validate or propagate changes to a `Machine` after initial creation meaning a user can update their `Machine` to use e.g. an invalid network name. While this would have no immediate effect - remember, the changes aren't propagated - it would prevent the users deleting the Machine since validation would fail repeatedly.

Avoid all of this by not building the whole `InstanceSpec`. Instead, build only what we need: the root volume information.
