### PR TITLE
OCPBUGS-22319: fix MachineToInstanceSpec when SG are nil

### DIFF
--- a/pkg/machine/convert.go
+++ b/pkg/machine/convert.go
@@ -314,7 +314,10 @@ func MachineToInstanceSpec(machine *machinev1beta1.Machine, apiVIPs, ingressVIPs
 	}
 
 	for _, port := range ps.Ports {
-		portSecurityGroupParams := securityGroupsToSecurityGroupParams(*port.SecurityGroups)
+		var portSecurityGroupParams []machinev1alpha1.SecurityGroupParam
+		if port.SecurityGroups != nil {
+			portSecurityGroupParams = securityGroupsToSecurityGroupParams(*port.SecurityGroups)
+		}
 		capoPort := capov1.PortOpts{
 			Network:              &capov1.NetworkFilter{ID: port.NetworkID},
 			NameSuffix:           port.NameSuffix,


### PR DESCRIPTION
Fixing `MachineToInstanceSpec` when there are no security groups in ports.
