### PR TITLE
OSASINFRA-3283: convert: add missing port profile

### DIFF
--- a/pkg/machine/convert.go
+++ b/pkg/machine/convert.go
@@ -176,6 +176,7 @@ func networkParamToCapov1PortOpt(net *machinev1alpha1.NetworkParam, apiVIPs, ing
 			VNICType:            net.VNICType,
 			FixedIPs:            fixedIPs,
 			Tags:                tags,
+			Profile:             portProfileToCapov1BindingProfile(net.Profile),
 		}
 
 		if len(addressPairs) > 0 {


### PR DESCRIPTION
during conversion to capo v1alpha7, we missed adding the port profile in
the else.
