### PR TITLE
NO-JIRA: Stop setting logtostderr flag and rely on defaults

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -55,8 +55,6 @@ var (
 )
 
 func main() {
-
-	flag.Set("logtostderr", "true")
 	watchNamespace := flag.String(
 		"namespace",
 		"",


### PR DESCRIPTION
The flag is set to true by default [1] and setting it like we do causes
a panic with go 1.21 [2]. There are also plans to remove the flag entirely
from future versions of k8s [3].

[1] https://github.com/kubernetes/klog/blob/e3f75b8af2707d64b5dd4c440ae8384ed2f2c386/klog.go#L407
[2] https://go-review.googlesource.com/c/go/+/480215
[3] https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/2845-deprecate-klog-specific-flags-in-k8s-components