### PR TITLE
Revendor CAPO

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	k8s.io/client-go v0.28.3
 	k8s.io/cluster-bootstrap v0.27.2
 	k8s.io/klog/v2 v2.100.1
-	sigs.k8s.io/cluster-api-provider-openstack v0.6.3
+	sigs.k8s.io/cluster-api-provider-openstack v0.8.0
 	sigs.k8s.io/controller-runtime v0.16.3
 	sigs.k8s.io/yaml v1.3.0
 )
@@ -120,5 +120,5 @@ require (
 replace (
 	github.com/elazarl/goproxy => github.com/elazarl/goproxy v0.0.0-20230731152917-f99041a5c027
 	sigs.k8s.io/cluster-api => sigs.k8s.io/cluster-api v1.5.2
-	sigs.k8s.io/cluster-api-provider-openstack => github.com/openshift/cluster-api-provider-openstack v0.8.0-beta.0.0.20231030165925-6fdfd82f7ad4
+	sigs.k8s.io/cluster-api-provider-openstack => github.com/openshift/cluster-api-provider-openstack v0.8.0-beta.0.0.20240205103940-d1de8c63ee93
 )

--- a/go.sum
+++ b/go.sum
@@ -218,8 +218,8 @@ github.com/openshift/api v0.0.0-20231030154605-972704c507c5 h1:lRQFuz3N+wOOUbUDX
 github.com/openshift/api v0.0.0-20231030154605-972704c507c5/go.mod h1:qNtV0315F+f8ld52TLtPvrfivZpdimOzTi3kn9IVbtU=
 github.com/openshift/client-go v0.0.0-20230926161409-848405da69e1 h1:W1N/3nVciqmjPjn2xldHjb0AwwCQzlGxLvX5BCgE8H4=
 github.com/openshift/client-go v0.0.0-20230926161409-848405da69e1/go.mod h1:ihUJrhBcYAGYQrJu/gP2OMgfVds5f5z5kbeLNBqjHLo=
-github.com/openshift/cluster-api-provider-openstack v0.8.0-beta.0.0.20231030165925-6fdfd82f7ad4 h1:skojFe9Ls6T8pgdTQ2BP0JC8bvJ7dOY9Pw4iQi7u+7I=
-github.com/openshift/cluster-api-provider-openstack v0.8.0-beta.0.0.20231030165925-6fdfd82f7ad4/go.mod h1:VzTZ+JUEfjmHBaFL9LsDxMAvj4coy0DHMX20Jf+HbGQ=
+github.com/openshift/cluster-api-provider-openstack v0.8.0-beta.0.0.20240205103940-d1de8c63ee93 h1:mvHYDOf0w1Z8wqdK5mxicXS9sD9CW4IrQNdH20I6gQA=
+github.com/openshift/cluster-api-provider-openstack v0.8.0-beta.0.0.20240205103940-d1de8c63ee93/go.mod h1:VzTZ+JUEfjmHBaFL9LsDxMAvj4coy0DHMX20Jf+HbGQ=
 github.com/openshift/library-go v0.0.0-20230927113136-405c34317fa4 h1:nNPH6wOCPP6XLDyHECflAlgW7xLorcUq7wl0vqyRQ34=
 github.com/openshift/library-go v0.0.0-20230927113136-405c34317fa4/go.mod h1:hl8bxWuFMM72N4YH7FKLGWtYhDz/A0xwvaa8Yr5fxYU=
 github.com/openshift/machine-api-operator v0.2.1-0.20231017175643-14a78838d36d h1:Gwiow7XAdRnd775I6VoeXEwOscvAzms/YMdffUFqBTg=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -841,7 +841,7 @@ sigs.k8s.io/cluster-api/feature
 sigs.k8s.io/cluster-api/util/labels/format
 sigs.k8s.io/cluster-api/util/topology
 sigs.k8s.io/cluster-api/util/version
-# sigs.k8s.io/cluster-api-provider-openstack v0.6.3 => github.com/openshift/cluster-api-provider-openstack v0.8.0-beta.0.0.20231030165925-6fdfd82f7ad4
+# sigs.k8s.io/cluster-api-provider-openstack v0.8.0 => github.com/openshift/cluster-api-provider-openstack v0.8.0-beta.0.0.20240205103940-d1de8c63ee93
 ## explicit; go 1.20
 sigs.k8s.io/cluster-api-provider-openstack/api/v1alpha7
 sigs.k8s.io/cluster-api-provider-openstack/pkg/clients
@@ -1003,4 +1003,4 @@ sigs.k8s.io/structured-merge-diff/v4/value
 sigs.k8s.io/yaml
 # github.com/elazarl/goproxy => github.com/elazarl/goproxy v0.0.0-20230731152917-f99041a5c027
 # sigs.k8s.io/cluster-api => sigs.k8s.io/cluster-api v1.5.2
-# sigs.k8s.io/cluster-api-provider-openstack => github.com/openshift/cluster-api-provider-openstack v0.8.0-beta.0.0.20231030165925-6fdfd82f7ad4
+# sigs.k8s.io/cluster-api-provider-openstack => github.com/openshift/cluster-api-provider-openstack v0.8.0-beta.0.0.20240205103940-d1de8c63ee93

--- a/vendor/sigs.k8s.io/cluster-api-provider-openstack/pkg/cloud/services/compute/instance.go
+++ b/vendor/sigs.k8s.io/cluster-api-provider-openstack/pkg/cloud/services/compute/instance.go
@@ -351,7 +351,7 @@ func (s *Service) createInstanceImpl(eventObject runtime.Object, openStackCluste
 		return createdInstance.State() == infrav1.InstanceStateActive, nil
 	})
 	if err != nil {
-		record.Warnf(eventObject, "FailedCreateServer", "Failed to create server %s: %v", createdInstance.Name(), err)
+		record.Warnf(eventObject, "FailedCreateServer", "Failed to create server %s: %v", instanceSpec.Name, err)
 		return nil, err
 	}
 


### PR DESCRIPTION
Point to the `release-4.15` branch of downstream CAPO, that is tracking upstream's `release-0.8` branch.

Because the `v0.8.0` tag upstream points to a commit that does not belong to the `release-0.8` branch, we're getting a `v0.8.0-beta-xxx` version in the go mod but this is indeed the stable v0.8 release branch.