### PR TITLE
OCPBUGS-30855: Ensure portSecurity is correctly set in the Port

### DIFF
--- a/pkg/machine/convert.go
+++ b/pkg/machine/convert.go
@@ -355,12 +355,18 @@ func MachineToInstanceSpec(machine *machinev1beta1.Machine, apiVIPs, ingressVIPs
 		if port.SecurityGroups != nil {
 			portSecurityGroupParams = securityGroupsToSecurityGroupParams(*port.SecurityGroups)
 		}
+		disablePortSecurity := port.PortSecurity
+		if disablePortSecurity != nil {
+			ps := !*disablePortSecurity
+			disablePortSecurity = &ps
+		}
 		capoPort := capov1.PortOpts{
 			Network:              &capov1.NetworkFilter{ID: port.NetworkID},
 			NameSuffix:           port.NameSuffix,
 			Description:          port.Description,
 			AdminStateUp:         port.AdminStateUp,
 			MACAddress:           port.MACAddress,
+			DisablePortSecurity:  disablePortSecurity,
 			FixedIPs:             make([]capov1.FixedIP, len(port.FixedIPs)),
 			SecurityGroupFilters: securityGroupParamToCapov1SecurityGroupFilter(portSecurityGroupParams),
 			VNICType:             port.VNICType,


### PR DESCRIPTION
Right now we only enforce portSecurity when it's defined
within the Machine's Network field, but the portSecurity
in the Machine's ports field should also be enforced.
This commit fixes the issue by ensuring the value of
PortSecurity is correctly set in the Server port.