### PR TITLE
OCPBUGS-48288: Stop ignoring port.tags field

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,9 @@ check-vendor:
 fmt:
 	hack/verify-gofmt.sh
 
+update:
+	hack/update-gofmt.sh
+
 lint:
 ifndef HAS_LINT
 		go get -u golang.org/x/lint/golint

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	k8s.io/cluster-bootstrap v0.30.1
 	k8s.io/component-base v0.30.2
 	k8s.io/klog/v2 v2.120.1
+	k8s.io/utils v0.0.0-20240502163921-fe8a2dddb1d0
 	sigs.k8s.io/cluster-api-provider-openstack v0.9.1
 	sigs.k8s.io/controller-runtime v0.18.4
 	sigs.k8s.io/yaml v1.4.0
@@ -110,7 +111,6 @@ require (
 	k8s.io/cli-runtime v0.30.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20240521193020-835d969ad83a // indirect
 	k8s.io/kubectl v0.30.0 // indirect
-	k8s.io/utils v0.0.0-20240502163921-fe8a2dddb1d0 // indirect
 	sigs.k8s.io/cluster-api v1.7.2 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/kustomize/api v0.17.2 // indirect

--- a/pkg/machine/convert.go
+++ b/pkg/machine/convert.go
@@ -231,7 +231,7 @@ func securityGroupParamToCapov1SecurityGroupFilter(psSecurityGroups []machinev1a
 			ID:          secGrp.Filter.ID,
 			Name:        secGrp.Filter.Name,
 			Description: secGrp.Filter.Description,
-			ProjectID:   secGrp.Filter.ProjectID,
+			ProjectID:   coalesce(secGrp.Filter.ProjectID, secGrp.Filter.TenantID),
 			Tags:        secGrp.Filter.Tags,
 			TagsAny:     secGrp.Filter.TagsAny,
 			NotTags:     secGrp.Filter.NotTags,

--- a/pkg/machine/convert.go
+++ b/pkg/machine/convert.go
@@ -171,6 +171,7 @@ func portOptsToCapov1PortOpts(port *machinev1alpha1.PortOpts, ignoreAddressPairs
 		Network:              &capov1.NetworkFilter{ID: port.NetworkID},
 		Profile:              portProfileToCapov1BindingProfile(port.Profile),
 		SecurityGroupFilters: securityGroupParamToCapov1SecurityGroupFilter(portSecurityGroupParams),
+		Tags:                 port.Tags,
 		Trunk:                port.Trunk,
 		VNICType:             port.VNICType,
 	}

--- a/pkg/machine/convert_test.go
+++ b/pkg/machine/convert_test.go
@@ -425,10 +425,9 @@ func TestPortOptsToCapov1PortOpts(t *testing.T) {
 				Network:              &capov1.NetworkFilter{ID: "c3127c12-fd96-4ab5-a4e0-dc4a69634f3b"},
 				Profile:              capov1.BindingProfile{},
 				SecurityGroupFilters: []capov1.SecurityGroupFilter{},
-				// OCPBUGS-48288: We should be setting tags
-				// Tags:                 []string{"foo", "bar"},
-				Trunk:    ptr.To(false),
-				VNICType: "",
+				Tags:                 []string{"foo", "bar"},
+				Trunk:                ptr.To(false),
+				VNICType:             "",
 			},
 		},
 	}

--- a/pkg/machine/convert_test.go
+++ b/pkg/machine/convert_test.go
@@ -183,6 +183,14 @@ func TestSecurityGroupParamToCapov1SecurityGroupFilter(t *testing.T) {
 		}
 	}
 
+	hasProjectID := func(want string) securityGroupFilterCheckFunc {
+		return func(t *testing.T, securityGroupFilter capov1.SecurityGroupFilter) {
+			if have := securityGroupFilter.ProjectID; want != have {
+				t.Errorf("expected securityGroupFilter to have project ID %q, found %q", want, have)
+			}
+		}
+	}
+
 	for _, tc := range [...]struct {
 		name                string
 		securityGroupParams []machinev1alpha1.SecurityGroupParam
@@ -218,6 +226,28 @@ func TestSecurityGroupParamToCapov1SecurityGroupFilter(t *testing.T) {
 				securityGroupFilter(0, hasSecurityGroupUUID("c0f694ff-aabf-479f-8fa2-589696c03715")),
 				securityGroupFilter(1, hasSecurityGroupUUID("c0f694ff-aabf-479f-8fa2-589696c03716")),
 				securityGroupFilter(2, hasSecurityGroupUUID("c0f694ff-aabf-479f-8fa2-589696c03717")),
+			),
+		},
+		{
+			name: "securityGroupParam with legacy tenantID params",
+			securityGroupParams: []machinev1alpha1.SecurityGroupParam{
+				{
+					UUID: "c0f694ff-aabf-479f-8fa2-589696c03715",
+					Filter: machinev1alpha1.SecurityGroupFilter{
+						TenantID: "c9cf6e858743443387730c0d53f82407",
+					},
+				},
+				{
+					UUID: "c0f694ff-aabf-479f-8fa2-589696c03716",
+					Filter: machinev1alpha1.SecurityGroupFilter{
+						ProjectID: "832fbb3cc73d4be894d468ef2ef75a4f",
+					},
+				},
+			},
+			check: that(
+				hasSecurityGroupFilters(2),
+				securityGroupFilter(0, hasProjectID("c9cf6e858743443387730c0d53f82407")),
+				securityGroupFilter(1, hasProjectID("832fbb3cc73d4be894d468ef2ef75a4f")),
 			),
 		},
 	} {


### PR DESCRIPTION
Drag code out to a separate function, add tests, then start setting the relevant field.
