### PR TITLE
OSASINFRA-3746: Consume CA cert from CCO secret

### DIFF
--- a/pkg/clients/machineservice.go
+++ b/pkg/clients/machineservice.go
@@ -39,12 +39,12 @@ type InstanceService struct {
 
 // TODO: Eventually we'll have a NewInstanceServiceFromCluster too
 func NewInstanceServiceFromMachine(kubeClient kubernetes.Interface, machine *machinev1.Machine) (*InstanceService, error) {
-	cloud, err := GetCloud(kubeClient, machine)
+	cloud, cacert, err := GetCloud(kubeClient, machine)
 	if err != nil {
 		return nil, err
 	}
 
-	return NewInstanceServiceFromCloud(cloud, GetCACertificate(kubeClient))
+	return NewInstanceServiceFromCloud(cloud, cacert)
 }
 
 func NewInstanceService() (*InstanceService, error) {

--- a/pkg/clients/utils.go
+++ b/pkg/clients/utils.go
@@ -20,43 +20,28 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-// GetCloud fetches cloud credentials from a secret and return a parsed Cloud structure
-func GetCloud(kubeClient kubernetes.Interface, machine *machinev1.Machine) (clientconfig.Cloud, error) {
+// GetCloud fetches cloud credentials from a secret and return a parsed Cloud structure and optional CA cert
+func GetCloud(kubeClient kubernetes.Interface, machine *machinev1.Machine) (clientconfig.Cloud, []byte, error) {
 	cloud := clientconfig.Cloud{}
 	machineSpec, err := MachineSpecFromProviderSpec(machine.Spec.ProviderSpec)
 	if err != nil {
-		return cloud, fmt.Errorf("Failed to get Machine Spec from Provider Spec: %v", err)
+		return cloud, nil, fmt.Errorf("Failed to get Machine Spec from Provider Spec: %v", err)
 	}
 
 	if machineSpec.CloudsSecret == nil || machineSpec.CloudsSecret.Name == "" {
-		return cloud, fmt.Errorf("Cloud secret name can't be empty")
+		return cloud, nil, fmt.Errorf("Cloud secret name can't be empty")
 	}
 
 	namespace := machineSpec.CloudsSecret.Namespace
 	if namespace == "" {
 		namespace = machine.Namespace
 	}
-	cloud, err = GetCloudFromSecret(kubeClient, namespace, machineSpec.CloudsSecret.Name, machineSpec.CloudName)
+	cloud, cacert, err := getCloudFromSecret(kubeClient, namespace, machineSpec.CloudsSecret.Name, machineSpec.CloudName)
 	if err != nil {
-		return cloud, fmt.Errorf("Failed to get cloud from secret: %v", err)
+		return cloud, cacert, fmt.Errorf("Failed to get cloud from secret: %v", err)
 	}
 
-	return cloud, nil
-}
-
-// GetCACertificate gets the CA certificate from the configmap
-func GetCACertificate(kubeClient kubernetes.Interface) []byte {
-	cloudConfig, err := kubeClient.CoreV1().ConfigMaps("openshift-config").Get(context.TODO(), "cloud-provider-config", metav1.GetOptions{})
-	if err != nil {
-		klog.Warningf("failed to get configmap openshift-config/cloud-provider-config from kubernetes api: %v", err)
-		return nil
-	}
-
-	if cacert, ok := cloudConfig.Data["ca-bundle.pem"]; ok {
-		return []byte(cacert)
-	}
-
-	return nil
+	return cloud, cacert, nil
 }
 
 // GetProviderClient returns an authenticated provider client based on values in the cloud structure
@@ -115,33 +100,50 @@ func GetProviderClient(cloud clientconfig.Cloud, cert []byte) (*gophercloud.Prov
 	return provider, nil
 }
 
-func GetCloudFromSecret(kubeClient kubernetes.Interface, namespace string, secretName string, cloudName string) (clientconfig.Cloud, error) {
+func getCloudFromSecret(kubeClient kubernetes.Interface, namespace string, secretName string, cloudName string) (clientconfig.Cloud, []byte, error) {
 	emptyCloud := clientconfig.Cloud{}
 
 	if secretName == "" {
-		return emptyCloud, nil
+		return emptyCloud, nil, nil
 	}
 
 	if secretName != "" && cloudName == "" {
-		return emptyCloud, fmt.Errorf("Secret name set to %v but no cloud was specified. Please set cloud_name in your machine spec.", secretName)
+		return emptyCloud, nil, fmt.Errorf("Secret name set to %v but no cloud was specified. Please set cloud_name in your machine spec.", secretName)
 	}
 
 	secret, err := kubeClient.CoreV1().Secrets(namespace).Get(context.TODO(), secretName, metav1.GetOptions{})
 	if err != nil {
-		return emptyCloud, fmt.Errorf("Failed to get secrets %s/%s from kubernetes api: %v", namespace, secretName, err)
+		return emptyCloud, nil, fmt.Errorf("Failed to get secrets %s/%s from kubernetes api: %v", namespace, secretName, err)
 	}
 
 	content, ok := secret.Data["clouds.yaml"]
 	if !ok {
-		return emptyCloud, fmt.Errorf("OpenStack credentials secret %v did not contain key %v", secretName, "clouds.yaml")
+		return emptyCloud, nil, fmt.Errorf("OpenStack credentials secret %v did not contain key %v", secretName, "clouds.yaml")
 	}
 	var clouds clientconfig.Clouds
 	err = yaml.Unmarshal(content, &clouds)
 	if err != nil {
-		return emptyCloud, fmt.Errorf("failed to unmarshal clouds credentials stored in secret %v: %v", secretName, err)
+		return emptyCloud, nil, fmt.Errorf("failed to unmarshal clouds credentials stored in secret %v: %v", secretName, err)
 	}
 
-	return clouds.Clouds[cloudName], nil
+	cacert := getCACertificate(kubeClient)
+
+	return clouds.Clouds[cloudName], cacert, nil
+}
+
+// getCACertFromConfig gets the CA certificate from the CCM configmap
+func getCACertFromConfig(kubeClient kubernetes.Interface) []byte {
+	cloudConfig, err := kubeClient.CoreV1().ConfigMaps("openshift-config").Get(context.TODO(), "cloud-provider-config", metav1.GetOptions{})
+	if err != nil {
+		klog.Warningf("failed to get configmap openshift-config/cloud-provider-config from kubernetes api: %v", err)
+		return nil
+	}
+
+	if cacert, ok := cloudConfig.Data["ca-bundle.pem"]; ok {
+		return []byte(cacert)
+	}
+
+	return nil
 }
 
 // MachineSpecFromProviderSpec unmarshals a provider status into an OpenStack Machine Status type

--- a/pkg/clients/utils.go
+++ b/pkg/clients/utils.go
@@ -20,10 +20,6 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-const (
-	CloudsSecretKey = "clouds.yaml"
-)
-
 // GetCloud fetches cloud credentials from a secret and return a parsed Cloud structure
 func GetCloud(kubeClient kubernetes.Interface, machine *machinev1.Machine) (clientconfig.Cloud, error) {
 	cloud := clientconfig.Cloud{}
@@ -132,13 +128,12 @@ func GetCloudFromSecret(kubeClient kubernetes.Interface, namespace string, secre
 
 	secret, err := kubeClient.CoreV1().Secrets(namespace).Get(context.TODO(), secretName, metav1.GetOptions{})
 	if err != nil {
-		return emptyCloud, fmt.Errorf("Failed to get secrets from kubernetes api: %v", err)
+		return emptyCloud, fmt.Errorf("Failed to get secrets %s/%s from kubernetes api: %v", namespace, secretName, err)
 	}
 
-	content, ok := secret.Data[CloudsSecretKey]
+	content, ok := secret.Data["clouds.yaml"]
 	if !ok {
-		return emptyCloud, fmt.Errorf("OpenStack credentials secret %v did not contain key %v",
-			secretName, CloudsSecretKey)
+		return emptyCloud, fmt.Errorf("OpenStack credentials secret %v did not contain key %v", secretName, "clouds.yaml")
 	}
 	var clouds clientconfig.Clouds
 	err = yaml.Unmarshal(content, &clouds)

--- a/pkg/machine/actuator.go
+++ b/pkg/machine/actuator.go
@@ -82,12 +82,12 @@ func NewActuator(params ActuatorParams) (*OpenstackClient, error) {
 func (oc *OpenstackClient) getScope(ctx context.Context, machine *machinev1.Machine) (scope.Scope, string, error) {
 	log := ctrl.LoggerFrom(ctx)
 	log = log.WithValues("machine", machine.Name)
-	cloud, err := clients.GetCloud(oc.params.KubeClient, machine)
+	cloud, cacert, err := clients.GetCloud(oc.params.KubeClient, machine)
 	if err != nil {
 		return nil, "", err
 	}
 	regionName := cloud.RegionName
-	scope, err := scope.NewProviderScope(cloud, clients.GetCACertificate(oc.params.KubeClient), log)
+	scope, err := scope.NewProviderScope(cloud, cacert, log)
 	return scope, regionName, err
 }
 


### PR DESCRIPTION
In openshift/cloud-credential-operator/pull/780, we have added the ability for `cloud-credential-operator` to consume a CA cert from the root credentials secret and to include in the credentials secrets it provisions.
In openshift/installer/pull/9194, we have modified the Installer to start setting this field where necessary.

Adapt MAPO to allow it to start consuming the CA cert from this place. We maintain fallbacks for the previous locations of the cert for now, but these can be removed in the next release.

This needs wait for the CCO change to be approved before we merge this.

/hold
