### PR TITLE
ART-12521: update go mod dependency for konflux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,7 +118,6 @@ kubernetes.tar.gz
 # generated files in any directory
 # TODO(thockin): uncomment this when we stop committing the generated files.
 #zz_generated.*
-zz_generated.openapi.go
 
 # make-related metadata
 /.make/


### PR DESCRIPTION
Image build was failing on Konflux due to missing go mod dependencies.

```
2025-04-04 17:27:03,471 INFO Vendoring the gomod dependencies
2025-04-04 17:27:08,506 ERROR vendor directory changed after vendoring:
A	vendor/sigs.k8s.io/cluster-api/api/v1beta1/zz_generated.openapi.go
2025-04-04 17:27:09,940 ERROR PackageRejected: The content of the vendor directory is not consistent with go.mod. Please check the logs for more details.
```

Konflux ignores .gitignore files since its a possible security gap. 