### PR TITLE
OCPBUGS-76788: Fix make test

### DIFF
--- a/hack/ci-test.sh
+++ b/hack/ci-test.sh
@@ -20,8 +20,14 @@ set -o pipefail
 
 REPO_ROOT=$(dirname "${BASH_SOURCE}")/..
 
-cd $REPO_ROOT && \
-	source ./hack/fetch_ext_bins.sh && \
+cd $REPO_ROOT
+
+# The only test that requires kubebuilder-tools (envtest) is currently skipped
+# (see pkg/machineset/controller_suite_test.go). Skip downloading the tools
+# until the envtest test is re-enabled.
+SKIP_FETCH_TOOLS=1
+
+source ./hack/fetch_ext_bins.sh && \
 	fetch_tools && \
 	setup_envs && \
 	make unit

--- a/hack/fetch_ext_bins.sh
+++ b/hack/fetch_ext_bins.sh
@@ -93,15 +93,21 @@ function fetch_tools {
   fi
 
   header_text "fetching tools"
-  kb_tools_archive_name="kubebuilder-tools-$k8s_version-$goos-$goarch.tar.gz"
-  kb_tools_download_url="https://storage.googleapis.com/kubebuilder-tools/$kb_tools_archive_name"
+  kb_tools_archive_name="envtest-v$k8s_version-$goos-$goarch.tar.gz"
+  kb_tools_download_url="https://github.com/kubernetes-sigs/controller-tools/releases/download/envtest-v$k8s_version/$kb_tools_archive_name"
 
   kb_tools_archive_path="$tmp_root/$kb_tools_archive_name"
-  if [ ! -f $kb_tools_archive_path ]; then
-    curl -fsL ${kb_tools_download_url} -o "$kb_tools_archive_path"
+  if [ ! -f "$kb_tools_archive_path" ]; then
+    curl -fsL "${kb_tools_download_url}" -o "$kb_tools_archive_path"
   fi
 
   tar -zvxf "$kb_tools_archive_path" -C "$tmp_root/"
+
+  # The new archive extracts to controller-tools/envtest/ but the rest of
+  # the script expects binaries in kubebuilder/bin/. Move them into place.
+  mkdir -p "$kb_root_dir/bin"
+  mv "$tmp_root/controller-tools/envtest/"* "$kb_root_dir/bin/"
+  rm -rf "$tmp_root/controller-tools"
 }
 
 function setup_envs {


### PR DESCRIPTION
The `make test` target used started failing due to the kubebuilder-tools binary artifacts having a new URL. Fix the URL, and disable fetching the artifacts since they were not used anyway.