### PR TITLE
OCPBUGS-94016: Revendor CAPO

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -118,4 +118,7 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.6.0 // indirect
 )
 
-replace github.com/elazarl/goproxy => github.com/elazarl/goproxy v0.0.0-20230731152917-f99041a5c027
+replace (
+	github.com/elazarl/goproxy => github.com/elazarl/goproxy v0.0.0-20230731152917-f99041a5c027
+	sigs.k8s.io/cluster-api-provider-openstack => github.com/openshift/cluster-api-provider-openstack v0.9.1-0.20260608151417-e831b17e5462
+)

--- a/go.sum
+++ b/go.sum
@@ -429,6 +429,8 @@ github.com/openshift/client-go v0.0.0-20250710075018-396b36f983ee h1:tOtrrxfDEW8
 github.com/openshift/client-go v0.0.0-20250710075018-396b36f983ee/go.mod h1:zhRiYyNMk89llof2qEuGPWPD+joQPhCRUc2IK0SB510=
 github.com/openshift/cluster-api-actuator-pkg/testutils v0.0.0-20250718085303-e712b1ebf374 h1:ldUi0e64kdYJC2+ucB24GRXIXfMnI3NpSkcnalPqBGo=
 github.com/openshift/cluster-api-actuator-pkg/testutils v0.0.0-20250718085303-e712b1ebf374/go.mod h1:3P6CIJp8Wyvg5YrUxA5Pkd7p+zWAgAmmG/3aticLr4I=
+github.com/openshift/cluster-api-provider-openstack v0.9.1-0.20260608151417-e831b17e5462 h1:qSsWPLQLQZVCc6cfGUWMLz2s+V/gbjWH+ELDU3ujKfs=
+github.com/openshift/cluster-api-provider-openstack v0.9.1-0.20260608151417-e831b17e5462/go.mod h1:ecR9lx4XbOr3Gg2CGNgM3wguuV6l31Nd5rUccE+xjKs=
 github.com/openshift/cluster-control-plane-machine-set-operator v0.0.0-20250424110138-1dbf0c7a5d51 h1:WaM4FDg2BzGAHjZr/JlKxREIqBALiYBpdBqjAxXj49U=
 github.com/openshift/cluster-control-plane-machine-set-operator v0.0.0-20250424110138-1dbf0c7a5d51/go.mod h1:cp9GawS6eRLeQFvnAu0NVuh3grPSaVS5vRGdydle2HQ=
 github.com/openshift/library-go v0.0.0-20250711143941-47604345e7ea h1:0BNis5UGo5Z7J9GtRY1nw/pt8hWxIZqvfqnqH3eV5cs=
@@ -870,8 +872,6 @@ rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
 sigs.k8s.io/cluster-api v1.9.4 h1:pa2Ho50F9Js/Vv/Jy11TcpmGiqY2ukXCoDj/dY25Y7M=
 sigs.k8s.io/cluster-api v1.9.4/go.mod h1:9DjpPCxJJo7/mH+KceINNJHr9c5X9S9HEp2B8JG3Uv8=
-sigs.k8s.io/cluster-api-provider-openstack v0.9.3-0.20251120124404-2c507cd316ab h1:dfFGOVRVNqHn8iz6D/BVOE9hnzu10VifVEVVP92PkNU=
-sigs.k8s.io/cluster-api-provider-openstack v0.9.3-0.20251120124404-2c507cd316ab/go.mod h1:ecR9lx4XbOr3Gg2CGNgM3wguuV6l31Nd5rUccE+xjKs=
 sigs.k8s.io/controller-runtime v0.20.1 h1:JbGMAG/X94NeM3xvjenVUaBjy6Ui4Ogd/J5ZtjZnHaE=
 sigs.k8s.io/controller-runtime v0.20.1/go.mod h1:BrP3w158MwvB3ZbNpaAcIKkHQ7YGpYnzpoSTZ8E14WU=
 sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20240923090159-236e448db12c h1:w1vANkdIpYwbEZH0y1C7iJItgdEGvF9A3eCdRmLhg8I=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -978,7 +978,7 @@ k8s.io/utils/trace
 ## explicit; go 1.22.0
 sigs.k8s.io/cluster-api/api/v1beta1
 sigs.k8s.io/cluster-api/errors
-# sigs.k8s.io/cluster-api-provider-openstack v0.9.3-0.20251120124404-2c507cd316ab
+# sigs.k8s.io/cluster-api-provider-openstack v0.9.3-0.20251120124404-2c507cd316ab => github.com/openshift/cluster-api-provider-openstack v0.9.1-0.20260608151417-e831b17e5462
 ## explicit; go 1.20
 sigs.k8s.io/cluster-api-provider-openstack/api/v1alpha7
 sigs.k8s.io/cluster-api-provider-openstack/pkg/clients
@@ -1142,3 +1142,4 @@ sigs.k8s.io/yaml
 sigs.k8s.io/yaml/goyaml.v2
 sigs.k8s.io/yaml/goyaml.v3
 # github.com/elazarl/goproxy => github.com/elazarl/goproxy v0.0.0-20230731152917-f99041a5c027
+# sigs.k8s.io/cluster-api-provider-openstack => github.com/openshift/cluster-api-provider-openstack v0.9.1-0.20260608151417-e831b17e5462

--- a/vendor/sigs.k8s.io/cluster-api-provider-openstack/pkg/cloud/services/networking/port.go
+++ b/vendor/sigs.k8s.io/cluster-api-provider-openstack/pkg/cloud/services/networking/port.go
@@ -169,7 +169,28 @@ func (s *Service) GetOrCreatePort(eventObject runtime.Object, clusterName string
 	var tags []string
 	tags = append(tags, instanceTags...)
 	tags = append(tags, portOpts.Tags...)
+
+	tagsAreSupported := false
 	if len(tags) > 0 {
+		tagsAreSupported, err = s.getStdAttrTagSupport()
+
+		if err != nil {
+			record.Warnf(eventObject, "FailedGetTagSupport", "Failed to verify neutron support for the standard-attr-tag extension, skipping tags: %v", err)
+		}
+
+		// Return error if user sets port tags; Skip over but warn for instance tags
+		if !tagsAreSupported {
+			if len(portOpts.Tags) > 0 {
+				err = fmt.Errorf("cannot tag port %s using port tags; tags are configured but neutron does not support the standard-attr-tag extension", portName)
+				record.Warnf(eventObject, "FailedTagPort", "Failed to tag port %s: %v", portName, err)
+				return nil, err
+			}
+
+			record.Warnf(eventObject, "FailedTagPort", "Neutron does not support the standard-attr-tag extension, skipping instance tags for port %s", portName)
+		}
+	}
+
+	if len(tags) > 0 && tagsAreSupported {
 		if err = s.replaceAllAttributesTags(eventObject, portResource, port.ID, tags); err != nil {
 			record.Warnf(eventObject, "FailedReplaceTags", "Failed to replace port tags %s: %v", portName, err)
 			return nil, err
@@ -182,9 +203,12 @@ func (s *Service) GetOrCreatePort(eventObject runtime.Object, clusterName string
 			record.Warnf(eventObject, "FailedCreateTrunk", "Failed to create trunk for port %s: %v", portName, err)
 			return nil, err
 		}
-		if err = s.replaceAllAttributesTags(eventObject, trunkResource, trunk.ID, tags); err != nil {
-			record.Warnf(eventObject, "FailedReplaceTags", "Failed to replace trunk tags %s: %v", portName, err)
-			return nil, err
+
+		if tagsAreSupported {
+			if err = s.replaceAllAttributesTags(eventObject, trunkResource, trunk.ID, tags); err != nil {
+				record.Warnf(eventObject, "FailedReplaceTags", "Failed to replace trunk tags %s: %v", portName, err)
+				return nil, err
+			}
 		}
 	}
 

--- a/vendor/sigs.k8s.io/cluster-api-provider-openstack/pkg/cloud/services/networking/service.go
+++ b/vendor/sigs.k8s.io/cluster-api-provider-openstack/pkg/cloud/services/networking/service.go
@@ -90,3 +90,18 @@ func (s *Service) replaceAllAttributesTags(eventObject runtime.Object, resourceT
 	record.Eventf(eventObject, "SuccessfulReplaceAllAttributeTags", "Replaced all attributestags for %s with tags %s", resourceID, uniqueTags)
 	return nil
 }
+
+// Checks if neutron supports Standard Attributes Tag Extension
+func (s *Service) getStdAttrTagSupport() (bool, error) {
+	allExts, err := s.client.ListExtensions()
+	if err != nil {
+		return false, err
+	}
+
+	for _, ext := range allExts {
+		if ext.Alias == "standard-attr-tag" {
+			return true, nil
+		}
+	}
+	return false, nil
+}


### PR DESCRIPTION
Copy of #170 for OCP release-4.20

Backporting fix to **[OCPBUGS-77061](https://redhat.atlassian.net/browse/OCPBUGS-77061)**. The patch was applied to downstream CAPO on **release-0.90** [openshift/cluster-api-provider-openstack/pull/421](https://github.com/openshift/cluster-api-provider-openstack/pull/421); so, the patch must now be applied to MAPO through vendoring.
