### PR TITLE
OCPBUGS-94015: Revendor CAPO

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -118,4 +118,7 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 )
 
-replace github.com/elazarl/goproxy => github.com/elazarl/goproxy v0.0.0-20230731152917-f99041a5c027
+replace (
+	github.com/elazarl/goproxy => github.com/elazarl/goproxy v0.0.0-20230731152917-f99041a5c027
+	sigs.k8s.io/cluster-api-provider-openstack => github.com/openshift/cluster-api-provider-openstack v0.9.1-0.20260608151417-e831b17e5462
+)

--- a/go.sum
+++ b/go.sum
@@ -223,6 +223,8 @@ github.com/openshift/client-go v0.0.0-20240904134955-cd42fd3d7408 h1:xHOmkHjN0AF
 github.com/openshift/client-go v0.0.0-20240904134955-cd42fd3d7408/go.mod h1:D3yfotGqRY1LWaHcoSCeadhdyvfrQWYJXui1M+JqKvY=
 github.com/openshift/cluster-api-actuator-pkg/testutils v0.0.0-20240626103413-ddea9c7c0aca h1:HFFzJznFQVudyVSpMa+hZwXZpc0ZvFCIpiMNFdf21g8=
 github.com/openshift/cluster-api-actuator-pkg/testutils v0.0.0-20240626103413-ddea9c7c0aca/go.mod h1:osVq9/R6qKHBQxDP4cYTvkgXVBKOMs1SOfPLFfn0m7A=
+github.com/openshift/cluster-api-provider-openstack v0.9.1-0.20260608151417-e831b17e5462 h1:qSsWPLQLQZVCc6cfGUWMLz2s+V/gbjWH+ELDU3ujKfs=
+github.com/openshift/cluster-api-provider-openstack v0.9.1-0.20260608151417-e831b17e5462/go.mod h1:ecR9lx4XbOr3Gg2CGNgM3wguuV6l31Nd5rUccE+xjKs=
 github.com/openshift/cluster-control-plane-machine-set-operator v0.0.0-20240909043600-373ac49835bf h1:mfMmaD9+vZIZQq3MGXsS/AGHXekj4wIn3zc1Cs1EY8M=
 github.com/openshift/cluster-control-plane-machine-set-operator v0.0.0-20240909043600-373ac49835bf/go.mod h1:2fZsjZ3QSPkoMUc8QntXfeBb8AnvW+WIYwwQX8vmgvQ=
 github.com/openshift/library-go v0.0.0-20240903143724-7c5c5d305ac1 h1:qEMLKQXdGlUiK1KC2k6QK8og38eveU2/gcNBnQAwwmk=
@@ -552,8 +554,6 @@ rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
 sigs.k8s.io/cluster-api v1.7.2 h1:bRE8zoao7ajuLC0HijqfZVcubKQCPlZ04HMgcA53FGE=
 sigs.k8s.io/cluster-api v1.7.2/go.mod h1:V9ZhKLvQtsDODwjXOKgbitjyCmC71yMBwDcMyNNIov0=
-sigs.k8s.io/cluster-api-provider-openstack v0.9.3-0.20251120124404-2c507cd316ab h1:dfFGOVRVNqHn8iz6D/BVOE9hnzu10VifVEVVP92PkNU=
-sigs.k8s.io/cluster-api-provider-openstack v0.9.3-0.20251120124404-2c507cd316ab/go.mod h1:ecR9lx4XbOr3Gg2CGNgM3wguuV6l31Nd5rUccE+xjKs=
 sigs.k8s.io/controller-runtime v0.18.4 h1:87+guW1zhvuPLh1PHybKdYFLU0YJp4FhJRmiHvm5BZw=
 sigs.k8s.io/controller-runtime v0.18.4/go.mod h1:TVoGrfdpbA9VRFaRnKgk9P5/atA0pMwq+f+msb9M8Sg=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMmr1bNJefnuqLsRAsHZo=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -847,7 +847,7 @@ k8s.io/utils/trace
 ## explicit; go 1.21
 sigs.k8s.io/cluster-api/api/v1beta1
 sigs.k8s.io/cluster-api/errors
-# sigs.k8s.io/cluster-api-provider-openstack v0.9.3-0.20251120124404-2c507cd316ab
+# sigs.k8s.io/cluster-api-provider-openstack v0.9.3-0.20251120124404-2c507cd316ab => github.com/openshift/cluster-api-provider-openstack v0.9.1-0.20260608151417-e831b17e5462
 ## explicit; go 1.20
 sigs.k8s.io/cluster-api-provider-openstack/api/v1alpha7
 sigs.k8s.io/cluster-api-provider-openstack/pkg/clients
@@ -1009,3 +1009,4 @@ sigs.k8s.io/yaml
 sigs.k8s.io/yaml/goyaml.v2
 sigs.k8s.io/yaml/goyaml.v3
 # github.com/elazarl/goproxy => github.com/elazarl/goproxy v0.0.0-20230731152917-f99041a5c027
+# sigs.k8s.io/cluster-api-provider-openstack => github.com/openshift/cluster-api-provider-openstack v0.9.1-0.20260608151417-e831b17e5462

--- a/vendor/sigs.k8s.io/cluster-api-provider-openstack/pkg/cloud/services/networking/port.go
+++ b/vendor/sigs.k8s.io/cluster-api-provider-openstack/pkg/cloud/services/networking/port.go
@@ -169,7 +169,28 @@ func (s *Service) GetOrCreatePort(eventObject runtime.Object, clusterName string
 	var tags []string
 	tags = append(tags, instanceTags...)
 	tags = append(tags, portOpts.Tags...)
+
+	tagsAreSupported := false
 	if len(tags) > 0 {
+		tagsAreSupported, err = s.getStdAttrTagSupport()
+
+		if err != nil {
+			record.Warnf(eventObject, "FailedGetTagSupport", "Failed to verify neutron support for the standard-attr-tag extension, skipping tags: %v", err)
+		}
+
+		// Return error if user sets port tags; Skip over but warn for instance tags
+		if !tagsAreSupported {
+			if len(portOpts.Tags) > 0 {
+				err = fmt.Errorf("cannot tag port %s using port tags; tags are configured but neutron does not support the standard-attr-tag extension", portName)
+				record.Warnf(eventObject, "FailedTagPort", "Failed to tag port %s: %v", portName, err)
+				return nil, err
+			}
+
+			record.Warnf(eventObject, "FailedTagPort", "Neutron does not support the standard-attr-tag extension, skipping instance tags for port %s", portName)
+		}
+	}
+
+	if len(tags) > 0 && tagsAreSupported {
 		if err = s.replaceAllAttributesTags(eventObject, portResource, port.ID, tags); err != nil {
 			record.Warnf(eventObject, "FailedReplaceTags", "Failed to replace port tags %s: %v", portName, err)
 			return nil, err
@@ -182,9 +203,12 @@ func (s *Service) GetOrCreatePort(eventObject runtime.Object, clusterName string
 			record.Warnf(eventObject, "FailedCreateTrunk", "Failed to create trunk for port %s: %v", portName, err)
 			return nil, err
 		}
-		if err = s.replaceAllAttributesTags(eventObject, trunkResource, trunk.ID, tags); err != nil {
-			record.Warnf(eventObject, "FailedReplaceTags", "Failed to replace trunk tags %s: %v", portName, err)
-			return nil, err
+
+		if tagsAreSupported {
+			if err = s.replaceAllAttributesTags(eventObject, trunkResource, trunk.ID, tags); err != nil {
+				record.Warnf(eventObject, "FailedReplaceTags", "Failed to replace trunk tags %s: %v", portName, err)
+				return nil, err
+			}
 		}
 	}
 

--- a/vendor/sigs.k8s.io/cluster-api-provider-openstack/pkg/cloud/services/networking/service.go
+++ b/vendor/sigs.k8s.io/cluster-api-provider-openstack/pkg/cloud/services/networking/service.go
@@ -90,3 +90,18 @@ func (s *Service) replaceAllAttributesTags(eventObject runtime.Object, resourceT
 	record.Eventf(eventObject, "SuccessfulReplaceAllAttributeTags", "Replaced all attributestags for %s with tags %s", resourceID, uniqueTags)
 	return nil
 }
+
+// Checks if neutron supports Standard Attributes Tag Extension
+func (s *Service) getStdAttrTagSupport() (bool, error) {
+	allExts, err := s.client.ListExtensions()
+	if err != nil {
+		return false, err
+	}
+
+	for _, ext := range allExts {
+		if ext.Alias == "standard-attr-tag" {
+			return true, nil
+		}
+	}
+	return false, nil
+}


### PR DESCRIPTION
Copy of #170 for OCP release-4.19

Backporting fix to **[OCPBUGS-77061](https://redhat.atlassian.net/browse/OCPBUGS-77061)**. The patch was applied to downstream CAPO on **release-0.90** [openshift/cluster-api-provider-openstack/pull/421](https://github.com/openshift/cluster-api-provider-openstack/pull/421); so, the patch must now be applied to MAPO through vendoring.

